### PR TITLE
Replace Robinhood Chain explorer with robinscan

### DIFF
--- a/src/js/config.js
+++ b/src/js/config.js
@@ -306,7 +306,7 @@ export const customNetworks = [
     name: 'Robinhood',
     nativeCurrency: { name: 'ETH', symbol: 'ETH', decimals: 18 },
     rpcUrls: ['https://rpc.mainnet.chain.robinhood.com'],
-    blockExplorers: [{ name: 'Robinhood Chain explorer', url: 'https://robinhoodchain.blockscout.com' }]
+    blockExplorers: [{ name: 'Robinhood Chain explorer', url: 'https://robinscan.io' }]
   },
   {
     id: 4689,
@@ -1637,7 +1637,7 @@ export const NETWORKS = {
       "https://rpc.mainnet.chain.robinhood.com"
     ],
     "blockExplorerUrls": [
-      "https://robinhoodchain.blockscout.com"
+      "https://robinscan.io"
     ],
   },
   WORLDCHAIN: {

--- a/src/static/js/ethers_helper.js
+++ b/src/static/js/ethers_helper.js
@@ -4405,7 +4405,7 @@ function getErc20Prices(prices, pool, chain = "eth") {
       poolUrl = `https://monadscan.com/token/${pool.address}`;
       break;
     case "robinhood":
-      poolUrl = `https://robinhoodchain.blockscout.com/token/${pool.address}`;
+      poolUrl = `https://robinscan.io/token/${pool.address}`;
       break;
     case "worldchain":
       poolUrl = `https://worldscan.org/token/${pool.address}`;
@@ -5222,7 +5222,7 @@ async function printSynthetixPool(App, info, chain = "eth", customURLs) {
       _print(`<a target="_blank" href="https://monadscan.com/address/${info.stakingAddress}">Monad Scan</a>`);
       break;
     case "robinhood":
-      _print(`<a target="_blank" href="https://robinhoodchain.blockscout.com/address/${info.stakingAddress}">Robinhood Explorer</a>`);
+      _print(`<a target="_blank" href="https://robinscan.io/address/${info.stakingAddress}">Robinhood Explorer</a>`);
       break;
     case "worldchain":
       _print(`<a target="_blank" href="https://worldscan.org/address/${info.stakingAddress}">WorldChain Scan</a>`);
@@ -5534,7 +5534,7 @@ function getChainExplorerUrl(chain, address) {
     case "monad":
       return `https://monadscan.com/token/${address}`;
     case "robinhood":
-      return `https://robinhoodchain.blockscout.com/token/${address}`;
+      return `https://robinscan.io/token/${address}`;
     case "worldchain":
       return `https://worldscan.org/token/${address}`;
     case "katana":

--- a/src/static/js/general_helpers.js
+++ b/src/static/js/general_helpers.js
@@ -704,7 +704,7 @@ async function loadGeneralChefContract(App, tokens, prices, chef, chefAddress, c
       break;
     case "monad": _print(`<a href='https://monadscan.com/address/${chefAddress}' target='_blank'>Staking Contract</a>`);
       break;
-    case "robinhood": _print(`<a href='https://robinhoodchain.blockscout.com/address/${chefAddress}' target='_blank'>Staking Contract</a>`);
+    case "robinhood": _print(`<a href='https://robinscan.io/address/${chefAddress}' target='_blank'>Staking Contract</a>`);
       break;
   }
   _print(`Found ${poolCount} pools.\n`)

--- a/src/static/js/robinhood_uniswap_v4.js
+++ b/src/static/js/robinhood_uniswap_v4.js
@@ -458,7 +458,7 @@ const fallback_withdraw = async function (App, nft_manager_address_v4, sickleAdd
   _print('')
   _print('You could check your nfts on the nft position manager contract below')
   _print(
-    `<a target="_blank" href="https://robinhoodchain.blockscout.com/address/${sickleAddress}?tab=tokens_nfts">Nft Position Manager</a>`
+    `<a target="_blank" href="https://robinscan.io/address/${sickleAddress}?tab=tokens_nfts">Nft Position Manager</a>`
   )
   _print('')
   let log = document.getElementById('log')


### PR DESCRIPTION
Swaps the Robinhood Chain (4663) block explorer URLs to robinscan.io.

Robinscan is listed on chainlist, is way faster, and is being adopted by many platforms.