### PR TITLE
Ignore local agent tooling and scratch files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -204,3 +204,9 @@ dist/
 deploy.sh
 deploy-staging.sh
 deploy-proxy-server.sh
+
+# Local agent tooling and scratch files
+.claude/
+.codex/
+AGENTS.override.md
+CLAUDE.local.md


### PR DESCRIPTION
Agent session directories and local override files were untracked rather than ignored, leaving them one `git add -A` away from being committed. None has ever been committed — verified across all history.

`AGENTS.override.md` is the override filename the agent tools actually read (checked before `AGENTS.md`); `CLAUDE.local.md` is its counterpart.

No other change: this is six lines of `.gitignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xdkm31z51rS9EmT4gMhBbo
