### PR TITLE
Read Robinhood Uniswap v4 NFTs from chain instead of an indexer

### DIFF
--- a/src/js/sickle/protocols/uniswap_v4.js
+++ b/src/js/sickle/protocols/uniswap_v4.js
@@ -229,6 +229,58 @@ export async function getOwnedErc721TokenIdsViaProxy({ chainId, contractAddress,
     .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
 }
 
+const ERC721_TRANSFER_TOPIC = ethers.utils.id('Transfer(address,address,uint256)')
+
+// Enumerate an owner's ERC-721 token ids straight from Transfer logs.
+//
+// Uniswap v4's PositionManager is not ERC721Enumerable (no tokenOfOwnerByIndex),
+// and the collections are far too large to walk with ownerOf — Robinhood Chain
+// alone had ~1.8M minted position NFTs. Two topic-filtered log queries are the
+// only cheap onchain route, and they are exact: replaying every Transfer in and
+// out of the address yields current holdings, with burns covered because a burn
+// is a Transfer to the zero address.
+//
+// Deliberately two full-range requests and no more. Public RPCs rate-limit
+// bursts, and chunking a multi-million block chain from a browser is not
+// viable. If the node refuses a full range, throw so the caller can fall back
+// to an indexer rather than hammering it.
+export async function getOwnedErc721TokenIdsOnchain({ provider, contractAddress, ownerAddress, fromBlock = 0 }) {
+  if (!provider) throw new Error('Onchain NFT lookup needs a provider')
+  if (!contractAddress || !ownerAddress) throw new Error('Onchain NFT lookup needs a contract and an owner')
+
+  const ownerTopic = ethers.utils.hexZeroPad(ethers.utils.getAddress(ownerAddress), 32)
+  const base = { address: contractAddress, fromBlock, toBlock: 'latest' }
+
+  const [incoming, outgoing] = await Promise.all([
+    provider.getLogs({ ...base, topics: [ERC721_TRANSFER_TOPIC, null, ownerTopic] }),
+    provider.getLogs({ ...base, topics: [ERC721_TRANSFER_TOPIC, ownerTopic] }),
+  ])
+
+  // Order matters: the same token can arrive, leave, and arrive again. Replay
+  // both directions in chain order rather than diffing two sets.
+  const events = [...incoming, ...outgoing].sort(
+    (a, b) => a.blockNumber - b.blockNumber || a.logIndex - b.logIndex
+  )
+
+  const owner = normalizeAddress(ownerAddress)
+  const owned = new Set()
+
+  for (const log of events) {
+    const topics = log?.topics || []
+    if (topics.length < 4) continue
+
+    const to = normalizeAddress(ethers.utils.hexDataSlice(topics[2], 12))
+    const tokenId = BigInt(topics[3]).toString()
+
+    if (to === owner) owned.add(tokenId)
+    else owned.delete(tokenId)
+  }
+
+  return Array.from(owned)
+    .map(x => BigInt(x))
+    .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
+}
+
 export function decodeSignedIntN(unsigned, bits) {
   const u = BigInt(unsigned)
   const b = BigInt(bits)

--- a/src/static/js/robinhood_uniswap_v4.js
+++ b/src/static/js/robinhood_uniswap_v4.js
@@ -161,6 +161,43 @@ async function getOwnedErc721TokenIdsViaProxy({ chainId, contractAddress, ownerA
   return uniswapV4Helpers().getOwnedErc721TokenIdsViaProxy({ chainId, contractAddress, ownerAddress })
 }
 
+// Read through the chain's own RPC rather than the wallet's. Over WalletConnect
+// the wallet provider serves reads from whatever endpoint it happens to use for
+// this chain, which need not carry log history.
+function robinhoodReadProvider(App) {
+  const rpcUrl = window.NETWORKS?.ROBINHOOD?.rpcUrls?.[0]
+  if (rpcUrl) {
+    try {
+      return new ethers.providers.JsonRpcProvider(rpcUrl)
+    } catch (e) {
+      console.log('Falling back to the wallet provider for reads:', e)
+    }
+  }
+  return App.provider
+}
+
+// Onchain enumeration first: it needs no API key and no vendor chain coverage.
+// Etherscan v2 does not index Robinhood Chain at all, so the proxy is only a
+// fallback here, ahead of asking the user to type the NFT id in by hand.
+async function getOwnedNftIds(App, contractAddress, ownerAddress) {
+  try {
+    const ids = await uniswapV4Helpers().getOwnedErc721TokenIdsOnchain({
+      provider: robinhoodReadProvider(App),
+      contractAddress,
+      ownerAddress,
+    })
+    console.log(`Found ${ids.length} NFT(s) onchain for ${ownerAddress}`)
+    return ids
+  } catch (e) {
+    console.log('Onchain NFT lookup failed, trying the proxy:', e)
+    return getOwnedErc721TokenIdsViaProxy({
+      chainId: ROBINHOOD_CHAIN_ID,
+      contractAddress,
+      ownerAddress,
+    })
+  }
+}
+
 async function main() {
   const App = await init_ethers()
 
@@ -189,17 +226,13 @@ async function main() {
 }
 
 const withdraw_nfts = async function (App, nft_manager_v4, nft_manager_address_v4, sickleAddress) {
-  const nft_ids = await getOwnedErc721TokenIdsViaProxy({
-    chainId: ROBINHOOD_CHAIN_ID,
-    contractAddress: nft_manager_address_v4,
-    ownerAddress: sickleAddress,
-  })
+  const nft_ids = await getOwnedNftIds(App, nft_manager_address_v4, sickleAddress)
 
   let active_nfts = []
 
   if (nft_ids.length === 0) {
-    _print('No NFTs found via proxy')
-    throw new Error('No NFTs found via proxy')
+    _print('No NFTs found')
+    throw new Error('No NFTs found')
   }
 
   const liquidity_calls = nft_ids.map(nft => nft_manager_v4.getPositionLiquidity(nft))
@@ -213,7 +246,7 @@ const withdraw_nfts = async function (App, nft_manager_v4, nft_manager_address_v
 
   if (active_nfts.length === 0) {
     _print('No active NFTs')
-    throw new Error('No active NFTs found via proxy')
+    throw new Error('No active NFTs found')
   }
 
   let token_ids = ''
@@ -276,7 +309,7 @@ const withdraw_nfts = async function (App, nft_manager_v4, nft_manager_address_v
 
   if (positions.length === 0) {
     _print('No active NFTs')
-    throw new Error('No active NFTs found via proxy')
+    throw new Error('No active NFTs found')
   }
 
   for (const p of positions) {


### PR DESCRIPTION
The Robinhood Uniswap v4 page could never list a Sickle's positions. It enumerated NFTs through an Etherscan v2 endpoint that does not index chain 4663:

```
{"status":"0","message":"NOTOK","result":"Missing or unsupported chainid parameter (required for v2 api)"}
```

So every visit fell through to the manual "enter the NFT-ID" box — useless to anyone who doesn't already know their token id. The Moralis endpoint isn't an alternative either; that account's free plan is currently paused, so `/api/moralis/wallet-nfts` fails on **every** chain, not just this one:

```
Your Moralis Free usage is paused. Upgrade to a paid plan to resume usage.
```

## Why Transfer logs

I measured the alternatives against the live chain before picking one:

| Probe | Result |
|---|---|
| `supportsInterface(0x780e9d63)` — ERC721Enumerable | **false**, so no `tokenOfOwnerByIndex` |
| `nextTokenId()` | **1,812,185** — walking `ownerOf` across the supply is not an option |
| Full-range `eth_getLogs`, Transfer + owner topic | **75 events in 341ms** across all 54.5M blocks |

The node clearly has a topic index. Two owner-filtered queries — one incoming, one outgoing — replayed in chain order give exact current holdings, and burns are covered for free because a burn is a Transfer to the zero address.

Deliberately two requests and no more, both full range. Public RPCs rate-limit bursts (I tripped a 429 during testing right after pulling 7,734 events), and chunking a 54M-block chain from a browser isn't viable — so a node that refuses the range throws and the caller falls back rather than hammering it.

Reads go through the chain's own RPC rather than the wallet's, since a wallet provider needn't serve log history for a chain it's merely connected to.

The proxy stays as the fallback tier, ahead of manual entry.

## Verification

Against a Sickle holding five v4 positions:

- onchain enumeration returned 16 incoming and 11 outgoing transfers → **5 currently owned**, and `ownerOf` confirmed all 5 with 0 mismatches
- an independent source reported one of those token ids for the same Sickle; it is in the set
- driven in a browser over a real WalletConnect session, the page renders all five with pools, amounts and per-NFT actions instead of the manual-entry box
- failing only the `eth_getLogs` calls degrades to the proxy and then to manual entry, with no unhandled error

## Scope

Only the Robinhood page is switched over. The shared helper is generic, but other chains still use the proxy path, which works for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PFbHQfrzPjp2pfRd6cfeCd
