### PR TITLE
Give every Uniswap v4 page the same NFT lookup ladder

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -7,3 +7,9 @@ PORT=8787
 ETHERSCAN_API_KEY=
 SNOWTRACE_API_KEY=
 
+# Upstream for /api/positions. Leave unset to disable that endpoint (501).
+# Must accept ?addresses=0x... and return position rows carrying nft.id and
+# nft.managerAddress.
+POSITIONS_API_URL=
+POSITIONS_API_KEY=
+

--- a/server/proxy.mjs
+++ b/server/proxy.mjs
@@ -23,12 +23,21 @@ const SNOWTRACE_API_URL = process.env.SNOWTRACE_API_URL || 'https://api.snowtrac
 const ETHERSCAN_API_KEY = process.env.ETHERSCAN_API_KEY || ''
 const SNOWTRACE_API_KEY = process.env.SNOWTRACE_API_KEY || ''
 
+// Position lookup upstream. Configured here rather than in the page so the
+// browser only ever talks to vfat.tools and the upstream stays server-side.
+const POSITIONS_API_URL = process.env.POSITIONS_API_URL || ''
+const POSITIONS_API_KEY = process.env.POSITIONS_API_KEY || ''
+
 if (!ETHERSCAN_API_KEY) {
   console.warn('[proxy] ETHERSCAN_API_KEY is not set. Non-AVAX requests will fail.')
 }
 
 if (!SNOWTRACE_API_KEY) {
   console.warn('[proxy] SNOWTRACE_API_KEY is not set. AVAX (43114) requests will fail.')
+}
+
+if (!POSITIONS_API_URL) {
+  console.warn('[proxy] POSITIONS_API_URL is not set. /api/positions will report 501.')
 }
 
 const ALLOWED = new Set([
@@ -88,6 +97,41 @@ const server = http.createServer(async (req, res) => {
     // Health check
     if (url.pathname === '/healthz') {
       sendJson(res, 200, { ok: true })
+      return
+    }
+
+    // Position lookup, used as the last automatic tier of the v4 NFT lookup on
+    // chains the Etherscan plan does not cover.
+    // Example:
+    //   /api/positions?address=0x...
+    if (url.pathname === '/api/positions') {
+      if (!POSITIONS_API_URL) {
+        sendJson(res, 501, { error: 'Position lookup is not configured on this proxy' })
+        return
+      }
+
+      // Missing and malformed are both the caller's fault, so answer 400 rather
+      // than letting a thrown required-param error surface as a 500.
+      const address = url.searchParams.get('address') || ''
+      if (!/^0x[0-9a-fA-F]{40}$/u.test(address)) {
+        sendJson(res, 400, { error: 'address must be a 0x-prefixed 20-byte address' })
+        return
+      }
+
+      const upstream = new URL(POSITIONS_API_URL)
+      upstream.searchParams.set('addresses', address)
+
+      const headers = { accept: 'application/json' }
+      if (POSITIONS_API_KEY) headers.authorization = `Bearer ${POSITIONS_API_KEY}`
+
+      const upstreamResp = await fetch(upstream.toString(), { method: 'GET', headers })
+      const text = await upstreamResp.text()
+
+      res.writeHead(upstreamResp.status, {
+        'content-type': upstreamResp.headers.get('content-type') || 'application/json; charset=utf-8',
+        'cache-control': 'no-store',
+      })
+      res.end(text)
       return
     }
 

--- a/src/js/sickle/protocols/uniswap_v4.js
+++ b/src/js/sickle/protocols/uniswap_v4.js
@@ -169,6 +169,166 @@ export async function getOwnedErc721TokenIdsOnchain({ provider, contractAddress,
     .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
 }
 
+export function defaultPositionsProxyBases() {
+  // Same shape as the Etherscan proxy: the page only ever talks to vfat.tools,
+  // and the proxy decides what is upstream of it.
+  const hostname = (typeof window !== 'undefined' && window?.location?.hostname) || ''
+  if (isLocalhostHostname(hostname)) {
+    const protocol = (typeof window !== 'undefined' && window?.location?.protocol) || 'http:'
+    return [`${protocol}//${hostname}:8787/api/positions`, 'https://vfat.tools/api/positions']
+  }
+  return ['/api/positions']
+}
+
+export async function fetchPositionsViaProxy({ address }, opts = {}) {
+  const bases =
+    Array.isArray(opts.bases) && opts.bases.length > 0 ? opts.bases : defaultPositionsProxyBases()
+
+  const search = new URLSearchParams({ address: String(address) })
+
+  let lastErr = null
+  for (const base of bases) {
+    try {
+      const resp = await fetch(`${String(base).replace(/\?$/u, '')}?${search.toString()}`)
+      if (!resp.ok) throw new Error(`Positions request failed (${resp.status})`)
+      return await resp.json()
+    } catch (e) {
+      lastErr = e
+    }
+  }
+
+  throw new Error(`Positions request failed: ${lastErr?.message || lastErr}`)
+}
+
+// Positions are keyed by the connected wallet, not by the Sickle: the service
+// resolves the Sickle itself and reports it back on each row.
+export async function getOwnedErc721TokenIdsFromPositions({
+  chainId,
+  contractAddress,
+  ownerAddress,
+  walletAddress,
+  bases,
+}) {
+  const address = walletAddress || ownerAddress
+  if (!address) throw new Error('Positions lookup needs an address')
+
+  const payload = await fetchPositionsViaProxy({ address }, { bases })
+  const rows = Array.isArray(payload) ? payload : payload?.positions || payload?.balances || []
+
+  const manager = normalizeAddress(contractAddress)
+  const sickle = normalizeAddress(ownerAddress)
+  const chain = Number(chainId)
+  const owned = new Set()
+
+  for (const row of rows) {
+    if (Number(row?.chainId) !== chain) continue
+
+    const nft = row?.nft
+    if (!nft || nft.id == null) continue
+    if (normalizeAddress(nft.managerAddress) !== manager) continue
+
+    // Only count what this Sickle holds, not everything the wallet owns.
+    const holder = normalizeAddress(nft.ownerAddress || row?.sickleAddress)
+    if (sickle && holder && holder !== sickle) continue
+
+    try {
+      owned.add(BigInt(String(nft.id)).toString())
+    } catch {
+      // ignore ids the service reports in a shape we cannot parse
+    }
+  }
+
+  return Array.from(owned)
+    .map(x => BigInt(x))
+    .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
+}
+
+export function rpcUrlForChain(chainId) {
+  const networks = (typeof window !== 'undefined' && window.customNetworks) || []
+  const network = networks.find(n => Number(n?.id) === Number(chainId))
+  const url = network?.rpcUrls?.default?.http?.[0]
+  return typeof url === 'string' && url ? url : null
+}
+
+// Read logs through the chain's own RPC rather than the wallet's: a wallet
+// provider need not serve log history for a chain it is merely connected to.
+export function chainReadProvider(App, chainId) {
+  const rpcUrl = rpcUrlForChain(chainId)
+  if (rpcUrl) {
+    try {
+      return new ethers.providers.JsonRpcProvider(rpcUrl)
+    } catch (e) {
+      console.log('Falling back to the wallet provider for reads:', e)
+    }
+  }
+  return App?.provider || null
+}
+
+// One ladder for every v4 page, best source first.
+//
+// Onchain logs are exact and need no vendor coverage, but most public RPCs cap
+// eth_getLogs well below a full-history query, so the attempt is best-effort.
+// The indexer covers chains the RPC will not, and the positions service covers
+// chains the indexer's plan will not. Callers treat an empty result as "ask the
+// user for the id" rather than as an answer.
+export async function resolveOwnedErc721TokenIds({
+  App,
+  chainId,
+  contractAddress,
+  ownerAddress,
+  walletAddress,
+  fromBlock = 0,
+  bases,
+}) {
+  const tried = []
+
+  const provider = chainReadProvider(App, chainId)
+  if (provider) {
+    try {
+      const ids = await getOwnedErc721TokenIdsOnchain({
+        provider,
+        contractAddress,
+        ownerAddress,
+        fromBlock,
+      })
+      console.log(`Found ${ids.length} NFT(s) onchain for ${ownerAddress}`)
+      return ids
+    } catch (e) {
+      tried.push(`onchain: ${e?.message || e}`)
+    }
+  }
+
+  try {
+    const ids = await getOwnedErc721TokenIdsViaProxy({ chainId, contractAddress, ownerAddress, bases })
+    if (ids.length > 0) {
+      console.log(`Found ${ids.length} NFT(s) via the indexer for ${ownerAddress}`)
+      return ids
+    }
+    // An unsupported chain and a genuinely empty wallet look identical here, so
+    // keep going rather than reporting "none" on the indexer's say-so.
+    tried.push('indexer: nothing returned')
+  } catch (e) {
+    tried.push(`indexer: ${e?.message || e}`)
+  }
+
+  try {
+    const ids = await getOwnedErc721TokenIdsFromPositions({
+      chainId,
+      contractAddress,
+      ownerAddress,
+      walletAddress,
+      bases,
+    })
+    console.log(`Found ${ids.length} NFT(s) via positions for ${ownerAddress}`)
+    return ids
+  } catch (e) {
+    tried.push(`positions: ${e?.message || e}`)
+  }
+
+  console.log('No NFT source could answer:', tried.join(' | '))
+  return []
+}
+
 export function decodeSignedIntN(unsigned, bits) {
   const u = BigInt(unsigned)
   const b = BigInt(bits)

--- a/src/js/sickle/protocols/uniswap_v4.js
+++ b/src/js/sickle/protocols/uniswap_v4.js
@@ -291,8 +291,15 @@ export async function resolveOwnedErc721TokenIds({
         ownerAddress,
         fromBlock,
       })
-      console.log(`Found ${ids.length} NFT(s) onchain for ${ownerAddress}`)
-      return ids
+      if (ids.length > 0) {
+        console.log(`Found ${ids.length} NFT(s) onchain for ${ownerAddress}`)
+        return ids
+      }
+      // An RPC that quietly clamps the block range instead of refusing it
+      // returns a short answer, not an error, and an empty one is
+      // indistinguishable from holding nothing. On a page whose job is getting
+      // funds out, prefer asking another source over reporting "none".
+      tried.push('onchain: nothing returned')
     } catch (e) {
       tried.push(`onchain: ${e?.message || e}`)
     }

--- a/src/static/js/arbitrum_uniswap_v4.js
+++ b/src/static/js/arbitrum_uniswap_v4.js
@@ -117,6 +117,26 @@ const nft_manager_address_v4 = '0xd88F38F930b7952f2DB2432Cb002E7abbF3dD869'
 const sickle_factory_address = '0x53d9780DbD3831E3A797Fd215be4131636cD5FDf'
 const sweep_address = '0xf5090D2d52E9b390A562783B651D1A7480d56FBa'
 
+const ARBITRUM_CHAIN_ID = 42161
+
+function uniswapV4Helpers() {
+  const h = window?.protocols?.uniswapV4
+  if (!h) throw new Error('Uniswap v4 helpers not loaded (window.Sickle.protocols.uniswapV4)')
+  return h
+}
+
+// Onchain logs first, then the indexer, then the positions service. Each tier
+// covers chains the one before it cannot; see resolveOwnedErc721TokenIds.
+async function getOwnedNftIds({ App, chainId, contractAddress, ownerAddress }) {
+  return uniswapV4Helpers().resolveOwnedErc721TokenIds({
+    App,
+    chainId,
+    contractAddress,
+    ownerAddress,
+    walletAddress: App.YOUR_ADDRESS,
+  })
+}
+
 async function main() {
   const App = await init_ethers()
 
@@ -133,32 +153,21 @@ async function main() {
     _print_bold(`Your Sickle Address: ${sickleAddress}`)
     _print('')
 
-    const current_block = await App.provider.getBlockNumber()
-    const from_block = current_block - 90000000
-
-    const filtered_users_address = sickleAddress.toLowerCase().slice(2)
-
-    const filter = {
-      address: nft_manager_address_v4,
-      fromBlock: from_block,
-      toBlock: current_block,
-      topics: [
-        '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef', // topic0 (signature)
-        null, //topic1 (from address)
-        `0x000000000000000000000000${filtered_users_address}`, // topic2 (to address)
-        null, // topic3
-      ],
-    }
-
     try {
-      const logs = await App.provider.getLogs(filter)
+      // Previously this read only incoming Transfers over a fixed 90M block
+      // window, so a position the Sickle had since transferred away still
+      // showed up: getPositionLiquidity stays non-zero for a position someone
+      // else now owns, and the page offered Withdraw on it. The shared lookup
+      // replays transfers in both directions, and falls back when the RPC will
+      // not serve the range.
+      const nft_ids = await getOwnedNftIds({
+        App,
+        chainId: ARBITRUM_CHAIN_ID,
+        contractAddress: nft_manager_address_v4,
+        ownerAddress: sickleAddress,
+      })
 
-      let nft_ids = [],
-        active_nfts = []
-
-      for (const log of logs) {
-        nft_ids.push(BigInt(log.topics[3]))
-      }
+      let active_nfts = []
 
       const liquidity_calls = nft_ids.map(nft => nft_manager_v4.getPositionLiquidity(nft))
       const liquidities = await App.ethcallProvider.all(liquidity_calls)

--- a/src/static/js/arbitrum_uniswap_v4.js
+++ b/src/static/js/arbitrum_uniswap_v4.js
@@ -167,6 +167,14 @@ async function main() {
         ownerAddress: sickleAddress,
       })
 
+      // The lookup reports "nothing found" by returning empty rather than
+      // throwing, so turn that into the manual-entry path the catch below
+      // provides. Without this a failed lookup dead-ends on "No active NFTs"
+      // and leaves the user no way to withdraw by id.
+      if (nft_ids.length === 0) {
+        throw new Error('No NFTs found')
+      }
+
       let active_nfts = []
 
       const liquidity_calls = nft_ids.map(nft => nft_manager_v4.getPositionLiquidity(nft))

--- a/src/static/js/avax_uniswap_v4.js
+++ b/src/static/js/avax_uniswap_v4.js
@@ -121,8 +121,16 @@ function parseTokenIdFromNftTxRow(row) {
   return uniswapV4Helpers().parseTokenIdFromNftTxRow(row)
 }
 
-async function getOwnedErc721TokenIdsViaProxy({ chainId, contractAddress, ownerAddress }) {
-  return uniswapV4Helpers().getOwnedErc721TokenIdsViaProxy({ chainId, contractAddress, ownerAddress })
+// Onchain logs first, then the indexer, then the positions service. Each tier
+// covers chains the one before it cannot; see resolveOwnedErc721TokenIds.
+async function getOwnedNftIds({ App, chainId, contractAddress, ownerAddress }) {
+  return uniswapV4Helpers().resolveOwnedErc721TokenIds({
+    App,
+    chainId,
+    contractAddress,
+    ownerAddress,
+    walletAddress: App.YOUR_ADDRESS,
+  })
 }
 
 function decodeSignedIntN(unsigned, bits) {
@@ -196,7 +204,8 @@ async function main() {
 const withdraw_nfts = async function(App, nft_manager_v4, nft_manager_address_v4, sickleAddress, retry = 0) {
       // Prefer the Sickle address because that's where positions usually live.
       // If needed later, we can also try App.YOUR_ADDRESS and union the results.
-      const nft_ids = await getOwnedErc721TokenIdsViaProxy({
+      const nft_ids = await getOwnedNftIds({
+        App,
         chainId: AVAX_CHAIN_ID,
         contractAddress: nft_manager_address_v4,
         ownerAddress: sickleAddress,
@@ -205,8 +214,8 @@ const withdraw_nfts = async function(App, nft_manager_v4, nft_manager_address_v4
       let active_nfts = []
 
       if (nft_ids.length === 0) {
-        _print('No NFTs found via proxy')
-        throw new Error('No NFTs found via proxy')
+        _print('No NFTs found')
+        throw new Error('No NFTs found')
       }
 
       const liquidity_calls = nft_ids.map(nft => nft_manager_v4.getPositionLiquidity(nft))
@@ -283,7 +292,7 @@ const withdraw_nfts = async function(App, nft_manager_v4, nft_manager_address_v4
 
         if (positions.length === 0) {
           _print('No active NFTs')
-          throw new Error('No active NFTs found via proxy')
+          throw new Error('No active NFTs found')
         }
 
         for (const p of positions) {
@@ -453,7 +462,7 @@ const withdraw_nfts = async function(App, nft_manager_v4, nft_manager_address_v4
         _print('')
       } else {
         _print('No active NFTs')
-        throw new Error('No active NFTs found via proxy')
+        throw new Error('No active NFTs found')
       }
 }
 

--- a/src/static/js/base_uniswap_v4.js
+++ b/src/static/js/base_uniswap_v4.js
@@ -161,8 +161,16 @@ async function getV4PoolSlot0(App, poolIdBytes32) {
   return uniswapV4Helpers().getV4PoolSlot0(App, poolIdBytes32, state_view_address_v4)
 }
 
-async function getOwnedErc721TokenIdsViaProxy({ chainId, contractAddress, ownerAddress }) {
-  return uniswapV4Helpers().getOwnedErc721TokenIdsViaProxy({ chainId, contractAddress, ownerAddress })
+// Onchain logs first, then the indexer, then the positions service. Each tier
+// covers chains the one before it cannot; see resolveOwnedErc721TokenIds.
+async function getOwnedNftIds({ App, chainId, contractAddress, ownerAddress }) {
+  return uniswapV4Helpers().resolveOwnedErc721TokenIds({
+    App,
+    chainId,
+    contractAddress,
+    ownerAddress,
+    walletAddress: App.YOUR_ADDRESS,
+  })
 }
 
 async function main() {
@@ -195,7 +203,8 @@ async function main() {
 const withdraw_nfts = async function(App, nft_manager_v4, nft_manager_address_v4, sickleAddress, retry = 0) {
       // Prefer the Sickle address because that's where positions usually live.
       // If needed later, we can also try App.YOUR_ADDRESS and union the results.
-      const nft_ids = await getOwnedErc721TokenIdsViaProxy({
+      const nft_ids = await getOwnedNftIds({
+        App,
         chainId: BASE_CHAIN_ID,
         contractAddress: nft_manager_address_v4,
         ownerAddress: sickleAddress,
@@ -204,8 +213,8 @@ const withdraw_nfts = async function(App, nft_manager_v4, nft_manager_address_v4
       let active_nfts = []
 
       if (nft_ids.length === 0) {
-        _print('No NFTs found via proxy')
-        throw new Error('No NFTs found via proxy')
+        _print('No NFTs found')
+        throw new Error('No NFTs found')
       }
 
       const liquidity_calls = nft_ids.map(nft => nft_manager_v4.getPositionLiquidity(nft))
@@ -286,7 +295,7 @@ const withdraw_nfts = async function(App, nft_manager_v4, nft_manager_address_v4
 
         if (positions.length === 0) {
           _print('No active NFTs')
-          throw new Error('No active NFTs found via proxy')
+          throw new Error('No active NFTs found')
         }
 
         // Fetch slot0 per distinct pool and token metadata.
@@ -464,7 +473,7 @@ const withdraw_nfts = async function(App, nft_manager_v4, nft_manager_address_v4
         _print('')
       } else {
         _print('No active NFTs')
-        throw new Error('No active NFTs found via proxy')
+        throw new Error('No active NFTs found')
       }
 }
 

--- a/src/static/js/bsc_uniswap_v4.js
+++ b/src/static/js/bsc_uniswap_v4.js
@@ -184,8 +184,16 @@ function uniswapV4Helpers() {
   return h
 }
 
-async function getOwnedErc721TokenIdsViaProxy({ chainId, contractAddress, ownerAddress }) {
-  return uniswapV4Helpers().getOwnedErc721TokenIdsViaProxy({ chainId, contractAddress, ownerAddress })
+// Onchain logs first, then the indexer, then the positions service. Each tier
+// covers chains the one before it cannot; see resolveOwnedErc721TokenIds.
+async function getOwnedNftIds({ App, chainId, contractAddress, ownerAddress }) {
+  return uniswapV4Helpers().resolveOwnedErc721TokenIds({
+    App,
+    chainId,
+    contractAddress,
+    ownerAddress,
+    walletAddress: App.YOUR_ADDRESS,
+  })
 }
 
 function normalizePoolKey(poolKey) {
@@ -245,7 +253,8 @@ async function main() {
 
 const withdraw_nfts = async function(App, nft_manager_v4, nft_manager_address_v4, sickleAddress) {
   // Prefer the Sickle address because that's where positions usually live.
-  const nft_ids = await getOwnedErc721TokenIdsViaProxy({
+  const nft_ids = await getOwnedNftIds({
+    App,
     chainId: BSC_CHAIN_ID,
     contractAddress: nft_manager_address_v4,
     ownerAddress: sickleAddress,
@@ -254,8 +263,8 @@ const withdraw_nfts = async function(App, nft_manager_v4, nft_manager_address_v4
   let active_nfts = []
 
   if (nft_ids.length === 0) {
-    _print('No NFTs found via proxy')
-    throw new Error('No NFTs found via proxy')
+    _print('No NFTs found')
+    throw new Error('No NFTs found')
   }
 
   const liquidity_calls = nft_ids.map(nft => nft_manager_v4.getPositionLiquidity(nft))
@@ -333,7 +342,7 @@ const withdraw_nfts = async function(App, nft_manager_v4, nft_manager_address_v4
 
     if (positions.length === 0) {
       _print('No active NFTs')
-      throw new Error('No active NFTs found via proxy')
+      throw new Error('No active NFTs found')
     }
 
     // Fetch slot0 per distinct pool and token metadata.
@@ -508,7 +517,7 @@ const withdraw_nfts = async function(App, nft_manager_v4, nft_manager_address_v4
     _print('')
   } else {
     _print('No active NFTs')
-    throw new Error('No active NFTs found via proxy')
+    throw new Error('No active NFTs found')
   }
 }
 

--- a/src/static/js/monad_uniswap_v4.js
+++ b/src/static/js/monad_uniswap_v4.js
@@ -158,8 +158,16 @@ async function getV4PoolSlot0(App, poolIdBytes32) {
   return uniswapV4Helpers().getV4PoolSlot0(App, poolIdBytes32, state_view_address_v4)
 }
 
-async function getOwnedErc721TokenIdsViaProxy({ chainId, contractAddress, ownerAddress }) {
-  return uniswapV4Helpers().getOwnedErc721TokenIdsViaProxy({ chainId, contractAddress, ownerAddress })
+// Onchain logs first, then the indexer, then the positions service. Each tier
+// covers chains the one before it cannot; see resolveOwnedErc721TokenIds.
+async function getOwnedNftIds({ App, chainId, contractAddress, ownerAddress }) {
+  return uniswapV4Helpers().resolveOwnedErc721TokenIds({
+    App,
+    chainId,
+    contractAddress,
+    ownerAddress,
+    walletAddress: App.YOUR_ADDRESS,
+  })
 }
 
 async function main() {
@@ -190,7 +198,8 @@ async function main() {
 }
 
 const withdraw_nfts = async function(App, nft_manager_v4, nft_manager_address_v4, sickleAddress) {
-  const nft_ids = await getOwnedErc721TokenIdsViaProxy({
+  const nft_ids = await getOwnedNftIds({
+    App,
     chainId: MONAD_CHAIN_ID,
     contractAddress: nft_manager_address_v4,
     ownerAddress: sickleAddress,
@@ -199,8 +208,8 @@ const withdraw_nfts = async function(App, nft_manager_v4, nft_manager_address_v4
   let active_nfts = []
 
   if (nft_ids.length === 0) {
-    _print('No NFTs found via proxy')
-    throw new Error('No NFTs found via proxy')
+    _print('No NFTs found')
+    throw new Error('No NFTs found')
   }
 
   const liquidity_calls = nft_ids.map(nft => nft_manager_v4.getPositionLiquidity(nft))
@@ -214,7 +223,7 @@ const withdraw_nfts = async function(App, nft_manager_v4, nft_manager_address_v4
 
   if (active_nfts.length === 0) {
     _print('No active NFTs')
-    throw new Error('No active NFTs found via proxy')
+    throw new Error('No active NFTs found')
   }
 
   let token_ids = ''
@@ -277,7 +286,7 @@ const withdraw_nfts = async function(App, nft_manager_v4, nft_manager_address_v4
 
   if (positions.length === 0) {
     _print('No active NFTs')
-    throw new Error('No active NFTs found via proxy')
+    throw new Error('No active NFTs found')
   }
 
   for (const p of positions) {

--- a/src/static/js/optimism_uniswap_v4.js
+++ b/src/static/js/optimism_uniswap_v4.js
@@ -158,8 +158,16 @@ async function getV4PoolSlot0(App, poolIdBytes32) {
   return uniswapV4Helpers().getV4PoolSlot0(App, poolIdBytes32, state_view_address_v4)
 }
 
-async function getOwnedErc721TokenIdsViaProxy({ chainId, contractAddress, ownerAddress }) {
-  return uniswapV4Helpers().getOwnedErc721TokenIdsViaProxy({ chainId, contractAddress, ownerAddress })
+// Onchain logs first, then the indexer, then the positions service. Each tier
+// covers chains the one before it cannot; see resolveOwnedErc721TokenIds.
+async function getOwnedNftIds({ App, chainId, contractAddress, ownerAddress }) {
+  return uniswapV4Helpers().resolveOwnedErc721TokenIds({
+    App,
+    chainId,
+    contractAddress,
+    ownerAddress,
+    walletAddress: App.YOUR_ADDRESS,
+  })
 }
 
 async function main() {
@@ -191,7 +199,8 @@ async function main() {
 
 const withdraw_nfts = async function(App, nft_manager_v4, nft_manager_address_v4, sickleAddress) {
   // Prefer the Sickle address because that's where positions usually live.
-  const nft_ids = await getOwnedErc721TokenIdsViaProxy({
+  const nft_ids = await getOwnedNftIds({
+    App,
     chainId: OPTIMISM_CHAIN_ID,
     contractAddress: nft_manager_address_v4,
     ownerAddress: sickleAddress,
@@ -200,8 +209,8 @@ const withdraw_nfts = async function(App, nft_manager_v4, nft_manager_address_v4
   let active_nfts = []
 
   if (nft_ids.length === 0) {
-    _print('No NFTs found via proxy')
-    throw new Error('No NFTs found via proxy')
+    _print('No NFTs found')
+    throw new Error('No NFTs found')
   }
 
   const liquidity_calls = nft_ids.map(nft => nft_manager_v4.getPositionLiquidity(nft))
@@ -215,7 +224,7 @@ const withdraw_nfts = async function(App, nft_manager_v4, nft_manager_address_v4
 
   if (active_nfts.length === 0) {
     _print('No active NFTs')
-    throw new Error('No active NFTs found via proxy')
+    throw new Error('No active NFTs found')
   }
 
   let token_ids = ''
@@ -278,7 +287,7 @@ const withdraw_nfts = async function(App, nft_manager_v4, nft_manager_address_v4
 
   if (positions.length === 0) {
     _print('No active NFTs')
-    throw new Error('No active NFTs found via proxy')
+    throw new Error('No active NFTs found')
   }
 
   for (const p of positions) {

--- a/src/static/js/polygon_uniswap_v4.js
+++ b/src/static/js/polygon_uniswap_v4.js
@@ -158,8 +158,16 @@ async function getV4PoolSlot0(App, poolIdBytes32) {
   return uniswapV4Helpers().getV4PoolSlot0(App, poolIdBytes32, state_view_address_v4)
 }
 
-async function getOwnedErc721TokenIdsViaProxy({ chainId, contractAddress, ownerAddress }) {
-  return uniswapV4Helpers().getOwnedErc721TokenIdsViaProxy({ chainId, contractAddress, ownerAddress })
+// Onchain logs first, then the indexer, then the positions service. Each tier
+// covers chains the one before it cannot; see resolveOwnedErc721TokenIds.
+async function getOwnedNftIds({ App, chainId, contractAddress, ownerAddress }) {
+  return uniswapV4Helpers().resolveOwnedErc721TokenIds({
+    App,
+    chainId,
+    contractAddress,
+    ownerAddress,
+    walletAddress: App.YOUR_ADDRESS,
+  })
 }
 
 async function main() {
@@ -191,7 +199,8 @@ async function main() {
 
 const withdraw_nfts = async function(App, nft_manager_v4, nft_manager_address_v4, sickleAddress) {
   // Prefer the Sickle address because that's where positions usually live.
-  const nft_ids = await getOwnedErc721TokenIdsViaProxy({
+  const nft_ids = await getOwnedNftIds({
+    App,
     chainId: POLYGON_CHAIN_ID,
     contractAddress: nft_manager_address_v4,
     ownerAddress: sickleAddress,
@@ -200,8 +209,8 @@ const withdraw_nfts = async function(App, nft_manager_v4, nft_manager_address_v4
   let active_nfts = []
 
   if (nft_ids.length === 0) {
-    _print('No NFTs found via proxy')
-    throw new Error('No NFTs found via proxy')
+    _print('No NFTs found')
+    throw new Error('No NFTs found')
   }
 
   const liquidity_calls = nft_ids.map(nft => nft_manager_v4.getPositionLiquidity(nft))
@@ -215,7 +224,7 @@ const withdraw_nfts = async function(App, nft_manager_v4, nft_manager_address_v4
 
   if (active_nfts.length === 0) {
     _print('No active NFTs')
-    throw new Error('No active NFTs found via proxy')
+    throw new Error('No active NFTs found')
   }
 
   let token_ids = ''
@@ -278,7 +287,7 @@ const withdraw_nfts = async function(App, nft_manager_v4, nft_manager_address_v4
 
   if (positions.length === 0) {
     _print('No active NFTs')
-    throw new Error('No active NFTs found via proxy')
+    throw new Error('No active NFTs found')
   }
 
   for (const p of positions) {

--- a/src/static/js/robinhood_uniswap_v4.js
+++ b/src/static/js/robinhood_uniswap_v4.js
@@ -157,45 +157,16 @@ async function getV4PoolSlot0(App, poolIdBytes32) {
   return uniswapV4Helpers().getV4PoolSlot0(App, poolIdBytes32, state_view_address_v4)
 }
 
-async function getOwnedErc721TokenIdsViaProxy({ chainId, contractAddress, ownerAddress }) {
-  return uniswapV4Helpers().getOwnedErc721TokenIdsViaProxy({ chainId, contractAddress, ownerAddress })
-}
-
-// Read through the chain's own RPC rather than the wallet's. Over WalletConnect
-// the wallet provider serves reads from whatever endpoint it happens to use for
-// this chain, which need not carry log history.
-function robinhoodReadProvider(App) {
-  const rpcUrl = window.NETWORKS?.ROBINHOOD?.rpcUrls?.[0]
-  if (rpcUrl) {
-    try {
-      return new ethers.providers.JsonRpcProvider(rpcUrl)
-    } catch (e) {
-      console.log('Falling back to the wallet provider for reads:', e)
-    }
-  }
-  return App.provider
-}
-
-// Onchain enumeration first: it needs no API key and no vendor chain coverage.
-// Etherscan v2 does not index Robinhood Chain at all, so the proxy is only a
-// fallback here, ahead of asking the user to type the NFT id in by hand.
-async function getOwnedNftIds(App, contractAddress, ownerAddress) {
-  try {
-    const ids = await uniswapV4Helpers().getOwnedErc721TokenIdsOnchain({
-      provider: robinhoodReadProvider(App),
-      contractAddress,
-      ownerAddress,
-    })
-    console.log(`Found ${ids.length} NFT(s) onchain for ${ownerAddress}`)
-    return ids
-  } catch (e) {
-    console.log('Onchain NFT lookup failed, trying the proxy:', e)
-    return getOwnedErc721TokenIdsViaProxy({
-      chainId: ROBINHOOD_CHAIN_ID,
-      contractAddress,
-      ownerAddress,
-    })
-  }
+// Onchain logs first, then the indexer, then the positions service. Each tier
+// covers chains the one before it cannot; see resolveOwnedErc721TokenIds.
+async function getOwnedNftIds({ App, chainId, contractAddress, ownerAddress }) {
+  return uniswapV4Helpers().resolveOwnedErc721TokenIds({
+    App,
+    chainId,
+    contractAddress,
+    ownerAddress,
+    walletAddress: App.YOUR_ADDRESS,
+  })
 }
 
 async function main() {
@@ -226,7 +197,12 @@ async function main() {
 }
 
 const withdraw_nfts = async function (App, nft_manager_v4, nft_manager_address_v4, sickleAddress) {
-  const nft_ids = await getOwnedNftIds(App, nft_manager_address_v4, sickleAddress)
+  const nft_ids = await getOwnedNftIds({
+    App,
+    chainId: ROBINHOOD_CHAIN_ID,
+    contractAddress: nft_manager_address_v4,
+    ownerAddress: sickleAddress,
+  })
 
   let active_nfts = []
 

--- a/src/static/js/unichain_uniswap_v4.js
+++ b/src/static/js/unichain_uniswap_v4.js
@@ -158,8 +158,16 @@ async function getV4PoolSlot0(App, poolIdBytes32) {
   return uniswapV4Helpers().getV4PoolSlot0(App, poolIdBytes32, state_view_address_v4)
 }
 
-async function getOwnedErc721TokenIdsViaProxy({ chainId, contractAddress, ownerAddress }) {
-  return uniswapV4Helpers().getOwnedErc721TokenIdsViaProxy({ chainId, contractAddress, ownerAddress })
+// Onchain logs first, then the indexer, then the positions service. Each tier
+// covers chains the one before it cannot; see resolveOwnedErc721TokenIds.
+async function getOwnedNftIds({ App, chainId, contractAddress, ownerAddress }) {
+  return uniswapV4Helpers().resolveOwnedErc721TokenIds({
+    App,
+    chainId,
+    contractAddress,
+    ownerAddress,
+    walletAddress: App.YOUR_ADDRESS,
+  })
 }
 
 async function main() {
@@ -190,7 +198,8 @@ async function main() {
 }
 
 const withdraw_nfts = async function(App, nft_manager_v4, nft_manager_address_v4, sickleAddress) {
-  const nft_ids = await getOwnedErc721TokenIdsViaProxy({
+  const nft_ids = await getOwnedNftIds({
+    App,
     chainId: UNICHAIN_CHAIN_ID,
     contractAddress: nft_manager_address_v4,
     ownerAddress: sickleAddress,
@@ -199,8 +208,8 @@ const withdraw_nfts = async function(App, nft_manager_v4, nft_manager_address_v4
   let active_nfts = []
 
   if (nft_ids.length === 0) {
-    _print('No NFTs found via proxy')
-    throw new Error('No NFTs found via proxy')
+    _print('No NFTs found')
+    throw new Error('No NFTs found')
   }
 
   const liquidity_calls = nft_ids.map(nft => nft_manager_v4.getPositionLiquidity(nft))
@@ -214,7 +223,7 @@ const withdraw_nfts = async function(App, nft_manager_v4, nft_manager_address_v4
 
   if (active_nfts.length === 0) {
     _print('No active NFTs')
-    throw new Error('No active NFTs found via proxy')
+    throw new Error('No active NFTs found')
   }
 
   let token_ids = ''
@@ -277,7 +286,7 @@ const withdraw_nfts = async function(App, nft_manager_v4, nft_manager_address_v4
 
   if (positions.length === 0) {
     _print('No active NFTs')
-    throw new Error('No active NFTs found via proxy')
+    throw new Error('No active NFTs found')
   }
 
   for (const p of positions) {

--- a/src/static/js/uniswap_v4.js
+++ b/src/static/js/uniswap_v4.js
@@ -158,8 +158,16 @@ async function getV4PoolSlot0(App, poolIdBytes32) {
   return uniswapV4Helpers().getV4PoolSlot0(App, poolIdBytes32, state_view_address_v4)
 }
 
-async function getOwnedErc721TokenIdsViaProxy({ chainId, contractAddress, ownerAddress }) {
-  return uniswapV4Helpers().getOwnedErc721TokenIdsViaProxy({ chainId, contractAddress, ownerAddress })
+// Onchain logs first, then the indexer, then the positions service. Each tier
+// covers chains the one before it cannot; see resolveOwnedErc721TokenIds.
+async function getOwnedNftIds({ App, chainId, contractAddress, ownerAddress }) {
+  return uniswapV4Helpers().resolveOwnedErc721TokenIds({
+    App,
+    chainId,
+    contractAddress,
+    ownerAddress,
+    walletAddress: App.YOUR_ADDRESS,
+  })
 }
 
 async function main() {
@@ -191,7 +199,8 @@ async function main() {
 
 const withdraw_nfts = async function(App, nft_manager_v4, nft_manager_address_v4, sickleAddress) {
   // Prefer the Sickle address because that's where positions usually live.
-  const nft_ids = await getOwnedErc721TokenIdsViaProxy({
+  const nft_ids = await getOwnedNftIds({
+    App,
     chainId: MAINNET_CHAIN_ID,
     contractAddress: nft_manager_address_v4,
     ownerAddress: sickleAddress,
@@ -200,8 +209,8 @@ const withdraw_nfts = async function(App, nft_manager_v4, nft_manager_address_v4
   let active_nfts = []
 
   if (nft_ids.length === 0) {
-    _print('No NFTs found via proxy')
-    throw new Error('No NFTs found via proxy')
+    _print('No NFTs found')
+    throw new Error('No NFTs found')
   }
 
   const liquidity_calls = nft_ids.map(nft => nft_manager_v4.getPositionLiquidity(nft))
@@ -215,7 +224,7 @@ const withdraw_nfts = async function(App, nft_manager_v4, nft_manager_address_v4
 
   if (active_nfts.length === 0) {
     _print('No active NFTs')
-    throw new Error('No active NFTs found via proxy')
+    throw new Error('No active NFTs found')
   }
 
   let token_ids = ''
@@ -283,7 +292,7 @@ const withdraw_nfts = async function(App, nft_manager_v4, nft_manager_address_v4
 
   if (positions.length === 0) {
     _print('No active NFTs')
-    throw new Error('No active NFTs found via proxy')
+    throw new Error('No active NFTs found')
   }
 
   // Fetch slot0 per distinct pool and token metadata.


### PR DESCRIPTION
Every v4 page discovered a Sickle's position NFTs its own way, and each way had a chain it could not serve. Robinhood read Transfer logs, Arbitrum read logs differently and incorrectly, everyone else asked an indexer with uneven coverage. This replaces all of it with one shared lookup:

```
onchain Transfer logs  ->  indexer  ->  positions service  ->  ask the user
```

## Why a ladder rather than one source

No single source covers every chain. I probed each chain's configured RPC with a full-range owner-filtered `eth_getLogs`:

| chain | onchain logs | indexer |
|---|---|---|
| robinhood | **works** (113 events, 316ms) | no coverage for 4663 |
| ethereum, unichain, polygon, monad, arbitrum | capped or times out | **works** |
| base, optimism, bsc | capped | `Free API access is not supported for this chain` |
| avax | 2,048 block cap | `Phone verification required` |

Onchain is exact and needs no vendor coverage, but base and optimism cap at 10k blocks, avax 2k, monad 1k, bsc rejects even 2k, and arbitrum times out — so it is best-effort, not a general answer. Chunking to fit would be thousands of requests per page load.

The positions tier closes the remaining gap. It goes through the existing proxy, so the browser only ever talks to `vfat.tools` and the upstream stays server-side. It is configured by env (`POSITIONS_API_URL`) and returns **501 until set**, so this changes nothing for anyone who does not configure it.

**An empty answer from the indexer no longer ends the search.** An unsupported chain and a wallet holding nothing look identical there, and treating the first as the second is how a page tells someone they have no positions when it simply could not look.

## Arbitrum correctness fix

That page filtered Transfer logs to **incoming only**, over a fixed 90M block window, then kept anything with non-zero liquidity:

```js
topics: [ TRANSFER, null, `0x...${sickle}` ]   // incoming only
```

A position the Sickle had transferred away satisfies both tests — `getPositionLiquidity` stays non-zero for a position someone else now owns. So it was listed as the user's, with a Withdraw action against an NFT they no longer own. Replaying transfers in both directions is what makes the answer ownership rather than history.

## Verification

Against a Sickle holding five v4 positions:

- onchain returns all five and takes precedence
- with log queries failing, the ladder falls through to the positions tier and returns **only** that Sickle's NFTs on that chain — correctly excluding a decoy on another chain, one under a different manager, and one held by a different owner
- the endpoint answers 200 valid, 400 on missing or malformed address, 501 unconfigured
- CORS verified for the cross-origin dev case

Pages were re-tested through a real WalletConnect session against a coherent production build, with the loaded bundle confirmed to be the one built.

## Not in scope

Base, Optimism and BSC still have no working automatic source until either the indexer plan covers them or `POSITIONS_API_URL` is configured; Avax needs a dashboard action. Those are account-side, not code. The Polygon and Unichain RPC URLs in `customNetworks` also did not respond when probed, which is a separate issue that affects the wallet connector too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PFbHQfrzPjp2pfRd6cfeCd
