### PR TITLE
Stop re-checking the chain id around every RPC call

### DIFF
--- a/src/js/robinhood_alandale.js
+++ b/src/js/robinhood_alandale.js
@@ -593,7 +593,7 @@ const Alandale = (function () {
     if (toggle) toggle.addEventListener('click', function () { state.showZeroApr = !state.showZeroApr; renderFarms() })
   }
   function render () { renderWallet(); renderOverview(); renderFarms(); renderPositions() }
-  async function start () { state.rpc = new ethers.providers.JsonRpcProvider(chain.rpc, chain.number); bindEvents(); window.addEventListener('pagehide', clearWalletEvents, { once: true }); render(); const wallet = passiveWallet(); await loadRegistry(); await wallet; if (state.account) await refreshWallet() }
+  async function start () { state.rpc = new ethers.providers.StaticJsonRpcProvider(chain.rpc, { chainId: chain.number, name: 'robinhood' }); bindEvents(); window.addEventListener('pagehide', clearWalletEvents, { once: true }); render(); const wallet = passiveWallet(); await loadRegistry(); await wallet; if (state.account) await refreshWallet() }
   function fatal (error) { console.error(error); setLoading(); setStatus(errText(error), 'error'); render() }
   return { start: start, fatal: fatal }
 })()

--- a/src/js/robinhood_fables.js
+++ b/src/js/robinhood_fables.js
@@ -581,7 +581,7 @@ const FablesPage = (function () {
   }
 
   async function start () {
-    state.rpc = new ethers.providers.JsonRpcProvider({ url: chain.rpc, timeout: 20000 }, { chainId: chain.number, name: 'robinhood' })
+    state.rpc = new ethers.providers.StaticJsonRpcProvider({ url: chain.rpc, timeout: 20000 }, { chainId: chain.number, name: 'robinhood' })
     bindUi()
     const passive = restoreInjected().catch(error => setStatus(errText(error), 'error'))
     loading(true)

--- a/src/js/robinhood_morpho.js
+++ b/src/js/robinhood_morpho.js
@@ -670,7 +670,7 @@ const MorphoPage = (function () {
     state.latestBlock = await rpcRead('Reading latest Robinhood block', function () { return state.rpc.getBlockNumber() }); setLoading('Refreshing Morpho state...'); await hydrateMarkets(); await hydrateVaults(); await hydrateWallet(); setLoading(); render(); setStatus('Refreshed ' + state.markets.length + ' markets · ' + state.vaults.length + ' Vault V2.', 'success')
   }
   async function start () {
-    state.rpc = new ethers.providers.JsonRpcProvider(chain.rpc, chain.number); bindPageEvents(); render(); const passiveWallet = restoreInjectedWallet()
+    state.rpc = new ethers.providers.StaticJsonRpcProvider(chain.rpc, { chainId: chain.number, name: 'robinhood' }); bindPageEvents(); render(); const passiveWallet = restoreInjectedWallet()
     state.loading = true
     try { await discover(); setLoading('Reading Morpho token metadata...'); await loadTokens(); await hydrateMarkets(); await hydrateVaults(); await passiveWallet; await hydrateWallet(); setStatus('Loaded ' + state.markets.length + ' markets · ' + state.vaults.length + ' Vault V2.', 'success') } finally { state.loading = false; setLoading(); render() }
   }

--- a/src/js/robinhood_netnet.js
+++ b/src/js/robinhood_netnet.js
@@ -958,7 +958,7 @@ const NetNet = (function () {
   }
   function render () { renderWallet(); renderOverview(); renderFund(); renderStaking(); renderBonds(); renderNotes(); renderBuyback() }
   async function start () {
-    state.rpc = new ethers.providers.JsonRpcProvider(chain.rpc, chain.number)
+    state.rpc = new ethers.providers.StaticJsonRpcProvider(chain.rpc, { chainId: chain.number, name: 'robinhood' })
     bindEvents(); window.addEventListener('pagehide', clearWalletEvents, { once: true }); render()
     const wallet = passiveWallet()
     await loadFund()

--- a/src/js/robinhood_ramses.js
+++ b/src/js/robinhood_ramses.js
@@ -486,7 +486,7 @@ const RamsesPage = (function () {
   }
 
   async function start () {
-    state.rpc = new ethers.providers.JsonRpcProvider({ url: chain.rpc, timeout: 12000 }, { chainId: chain.number, name: 'robinhood' }); bindUi(); const passive = restoreInjected().catch(error => setStatus(errText(error), 'error')); setStatus('Pools'); await discover(); setStatus('V3'); await discoverV3().catch(function () { setStatus('V3 registry unavailable.', 'error') }); setStatus('Fees'); await loadFeeLogs(); await passive; await loadV3Positions(); loading(false); if (!state.status || ['Pools', 'V3'].includes(state.status) || state.status.indexOf('Fees') === 0) setStatus(''); render()
+    state.rpc = new ethers.providers.StaticJsonRpcProvider({ url: chain.rpc, timeout: 12000 }, { chainId: chain.number, name: 'robinhood' }); bindUi(); const passive = restoreInjected().catch(error => setStatus(errText(error), 'error')); setStatus('Pools'); await discover(); setStatus('V3'); await discoverV3().catch(function () { setStatus('V3 registry unavailable.', 'error') }); setStatus('Fees'); await loadFeeLogs(); await passive; await loadV3Positions(); loading(false); if (!state.status || ['Pools', 'V3'].includes(state.status) || state.status.indexOf('Fees') === 0) setStatus(''); render()
   }
 
   function fatal (error) { console.error(error); loading(false); setStatus(errText(error), 'error'); render() }

--- a/src/js/robinhood_raphael.js
+++ b/src/js/robinhood_raphael.js
@@ -764,7 +764,7 @@ const Raphael = (function () {
     if (create) create.addEventListener('click', function () { try { requireWallet(); openCreateLock() } catch (error) { setStatus(errText(error), 'error') } })
   }
   function render () { renderWallet(); renderOverview(); renderFarms(); renderPositions(); renderLocks() }
-  async function start () { state.rpc = new ethers.providers.JsonRpcProvider(chain.rpc, chain.number); bindEvents(); window.addEventListener('pagehide', clearWalletEvents, { once: true }); render(); const wallet = passiveWallet(); await loadRegistry(); await wallet; if (state.account) await refreshWallet() }
+  async function start () { state.rpc = new ethers.providers.StaticJsonRpcProvider(chain.rpc, { chainId: chain.number, name: 'robinhood' }); bindEvents(); window.addEventListener('pagehide', clearWalletEvents, { once: true }); render(); const wallet = passiveWallet(); await loadRegistry(); await wallet; if (state.account) await refreshWallet() }
   function fatal (error) { console.error(error); setLoading(); setStatus(errText(error), 'error'); render() }
   return { start: start, fatal: fatal }
 })()

--- a/src/js/robinhood_semi.js
+++ b/src/js/robinhood_semi.js
@@ -131,7 +131,7 @@ const Semi = (function () {
     }
   }
   function reader () {
-    if (!state.rpc) state.rpc = new ethers.providers.JsonRpcProvider(chain.rpc, chain.number)
+    if (!state.rpc) state.rpc = new ethers.providers.StaticJsonRpcProvider(chain.rpc, { chainId: chain.number, name: 'robinhood' })
     return state.rpc
   }
   function contract (address, abi, provider) {
@@ -566,7 +566,7 @@ const Semi = (function () {
   async function start () {
     state.app = byId('semi-app')
     state.loading = byId('semi-loading')
-    state.rpc = new ethers.providers.JsonRpcProvider(chain.rpc, chain.number)
+    state.rpc = new ethers.providers.StaticJsonRpcProvider(chain.rpc, { chainId: chain.number, name: 'robinhood' })
     setLoading('Reading SemiVault contracts on Robinhood Chain…')
     render()
     const passiveWallet = restoreInjectedWallet()

--- a/src/js/robinhood_up33.js
+++ b/src/js/robinhood_up33.js
@@ -151,7 +151,7 @@ const Up33 = (function () {
   const poolName = function (pool) { return pool.token0Info && pool.token1Info ? pool.token0Info.symbol + ' / ' + pool.token1Info.symbol : short(pool.address) }
 
   async function start() {
-    state.app = byId('up33-app'); state.rpc = new ethers.providers.JsonRpcProvider(chain.rpc, chain.number)
+    state.app = byId('up33-app'); state.rpc = new ethers.providers.StaticJsonRpcProvider(chain.rpc, { chainId: chain.number, name: 'robinhood' })
     setLoading('Reading current Up33 farm contracts from Robinhood Chain…')
     render()
     // Passive wallet restoration deliberately comes from the injected browser

--- a/src/js/sickle/protocols/uniswap_v4.js
+++ b/src/js/sickle/protocols/uniswap_v4.js
@@ -256,7 +256,13 @@ export function chainReadProvider(App, chainId) {
   const rpcUrl = rpcUrlForChain(chainId)
   if (rpcUrl) {
     try {
-      return new ethers.providers.JsonRpcProvider(rpcUrl)
+      // Static: a plain JsonRpcProvider re-checks eth_chainId around every
+      // call, and these RPCs bill that against the same rate budget as the
+      // reads we actually want.
+      return new ethers.providers.StaticJsonRpcProvider(rpcUrl, {
+        chainId: Number(chainId),
+        name: `eip155-${chainId}`,
+      })
     } catch (e) {
       console.log('Falling back to the wallet provider for reads:', e)
     }


### PR DESCRIPTION
Every read through `JsonRpcProvider` carried a companion `eth_chainId`. ethers v5 revalidates the network on each operation, and passing an explicit network does **not** suppress it — only `StaticJsonRpcProvider` caches the answer.

Measured against a local stub, for four `getLogs`:

| provider | requests |
|---|---|
| `JsonRpcProvider` (no network) | 3 × `eth_chainId` + 4 × `eth_getLogs` |
| `JsonRpcProvider` (+ explicit network) | 2 × `eth_chainId` + 4 × `eth_getLogs` |
| `StaticJsonRpcProvider` (+ network) | **0** × `eth_chainId` + 4 × `eth_getLogs` |

## Why it matters on this chain

Robinhood Chain's public RPC rate-limits per IP and counts these as ordinary requests, so a third of some pages' budget was spent confirming a chain id we hard-code anyway.

Worse, its rate-limit responses are unreadable to a browser: a `429` comes back with `Access-Control-Allow-Origin: *,*`, and a comma-joined value is rejected outright. So the page never sees the 429 — it gets an opaque `Failed to fetch` and cannot tell "slow down" from "endpoint dead". Every `200` I sampled had a clean single header; every `429` had the doubled one.

## Result

Fables, measured back to back against the deployed build:

| | HTTP requests | `eth_chainId` |
|---|---|---|
| deployed | 86 | 30 |
| this branch | **59** | **0** |

GIGA and the Sickle recovery page were already `Static`; this brings the remaining Robinhood pages and the shared v4 lookup in line. The v4 lookup was the worst case — a provider with no network at all, the three-call variant, on what is now the primary NFT source on Robinhood.

## What this does not do

It reduces load; it does not by itself bring Fables under the limit. Nothing is JSON-RPC batched and 38 `eth_call`s remain per load, so rate-limit failures are still reachable there. Batching those is the next lever and belongs in its own change.

Server-side proxying is *not* an option for this RPC: the limit is per-IP, so funnelling all users through one address would trip it far harder than distributed browser traffic.

The doubled CORS header on 429s is a bug on the RPC's side worth reporting upstream — it affects every dapp on the chain, not just us.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PFbHQfrzPjp2pfRd6cfeCd
