### PR TITLE
Replace two RPC endpoints that no longer resolve

### DIFF
--- a/src/js/config.js
+++ b/src/js/config.js
@@ -116,7 +116,7 @@ const rawNetworks = [
     id: 137,
     name: 'Polygon',
     nativeCurrency: { name: 'MATIC', symbol: 'MATIC', decimals: 18 },
-    rpcUrls: ['https://rpc-mainnet.matic.network'],
+    rpcUrls: ['https://polygon-bor-rpc.publicnode.com'],
     blockExplorers: [{ name: 'PolygonScan', url: 'https://polygonscan.com' }]
   },
   {
@@ -242,7 +242,7 @@ const rawNetworks = [
     id: 130,
     name: 'Unichain',
     nativeCurrency: { name: 'ETH', symbol: 'ETH', decimals: 18 },
-    rpcUrls: ['https://rpc.unichain.org'],
+    rpcUrls: ['https://mainnet.unichain.org'],
     blockExplorers: [{ name: 'Unichain Explorer', url: 'https://explorer.unichain.org' }]
   },
   {


### PR DESCRIPTION
The Polygon and Unichain entries point at hosts that no longer resolve. Not rate-limited, not capped — they fail to connect:

```
https://rpc-mainnet.matic.network   unreachable (fetch failed)
https://rpc.unichain.org            unreachable (fetch failed)
```

These are not decorative. `customNetworks` feeds the wallet connector, so this is the endpoint handed to a wallet in `wallet_addEthereumChain` when it does not already know the chain, and it is the endpoint the shared v4 lookup reads through.

## Replacements were vetted, not assumed

Three consecutive `eth_chainId` calls returning the right id, a live head, and a real `eth_call` decoding correctly:

| chain | endpoint | chainId | head | `decimals()` |
|---|---|---|---|---|
| polygon | `polygon-bor-rpc.publicnode.com` | 3/3 | 93250615 | 18 |
| unichain | `mainnet.unichain.org` | 3/3 | 57832593 | 18 |

Heads matched an independent provider on each chain, which is what distinguishes an endpoint that is in sync from one that merely responds. `polygon-rpc.com` was rejected — it failed all three chainId probes from this host.

## Not in scope

Neither endpoint can serve a full-history log query; nothing public on these chains can. I probed drpc, llamarpc, publicnode and the official endpoints across Polygon, Unichain, Base, Optimism, BSC, Arbitrum and Avax, and 10,000 blocks is the near-universal free-tier cap. That limit is unchanged here and is why the v4 lookup falls through to the indexer on those chains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PFbHQfrzPjp2pfRd6cfeCd
