### PR TITLE
Fix Katana chain id and Hemi page title

### DIFF
--- a/src/js/config.js
+++ b/src/js/config.js
@@ -519,7 +519,7 @@ const rawNetworks = [
     blockExplorers: [{ name: 'HyperScan', url: 'https://www.hyperscan.com/' }]
   },
   {
-    id: 747490,
+    id: 747474,
     name: 'Katana',
     nativeCurrency: { name: 'ETH', symbol: 'ETH', decimals: 18 },
     rpcUrls: ['https://rpc.katana.network'],

--- a/src/static/js/hemi.js
+++ b/src/static/js/hemi.js
@@ -5,7 +5,7 @@ $(function() {
 const main = async() => {
 
   let tableData = {
-    "title":"Katana Network",
+    "title":"Hemi Network",
     "heading":["Pool Provider","LP", "Reward Tokens", "INFO"],
     "rows": [
       ["Sickle                ", `<a href="sickle"         >Various</a>`,"              ",""]


### PR DESCRIPTION
## Katana chain id

The wallet network list registered Katana as **747490**. Katana is **747474**.

The same file already had it right in one place and wrong in the other:

| `src/js/config.js` | value | |
|---|---|---|
| `customNetworks` (line 522) | `id: 747490` | wrong |
| `NETWORKS.KATANA` | `"chainId": "0xb67d2"` = 747474 | correct |

So the wallet was asked to add/switch to a chain that does not exist, while the app's own network check looked for the real one. They could never match, Katana never read as connected, and the Sickle options on the Katana page were unreachable. That is the reported symptom.

Checked before changing it:

- `747490` appears nowhere else in the tree, so nothing depended on it and it was not a second network someone meant to add.
- The Katana RPC already in the config, `https://rpc.katana.network`, answers `eth_chainId` with `0xb67d2` — 747474. The `rpcUrls` and explorer entries beside the id were already correct; only the id was wrong.
- After the change the two entries agree and no `747490` remains.

## Hemi page title

Found while confirming the above: `src/static/js/hemi.js` was a **byte-for-byte copy** of `katana.js`, so the Hemi page rendered its heading as "Katana Network". Every other network page names itself after its own chain (`hyperevm.js` → "Hyperevm Network", `sonic.js` → "Sonic Network").

Included here because it is a one-line label fix found in the same pass, but it is independent of the chain id and easy to drop if you would rather it went separately.

## Verification

Both changed files parse (`node --check`). The change is one numeric literal and one string literal; no logic is touched.

Worth noting this only reaches users on the next site build and publish — the chain id is compiled into the bundle.