### PR TITLE
Apply the page copy standard to the pages 948651f1c3 missed

### DIFF
--- a/src/js/robinhood_semi.js
+++ b/src/js/robinhood_semi.js
@@ -506,8 +506,8 @@ const Semi = (function () {
       'TVL and supply share include both earning and pending stake.\n' +
       'Minimum lock after staking: ' + lockHours.toFixed(0) + ' hours.\n' +
       (isFinite(v.muUsd)
-        ? 'Dollar figures are anchored to USDG through the onchain USDG/MU pool.\nNo price API is used.'
-        : 'The USDG/MU pool could not be read, so no dollar figure is shown.\nEverything above is still live in SEMI and MU.')))
+        ? 'Dollar figures are anchored to USDG through the USDG/MU pool.'
+        : 'The USDG/MU pool could not be read, so no dollar figure is shown.')))
     node.appendChild(action('poke the ratchet', doPoke, !state.account || !onRobinhood()))
     return node
   }
@@ -519,7 +519,7 @@ const Semi = (function () {
         node.appendChild(document.createTextNode(' '))
         node.appendChild(action('other wallet', connectReown, false))
       }
-      node.appendChild(pre('Everything above is read without a wallet. Connect only to stake, unstake or claim.'))
+      node.appendChild(pre('Connect to stake, unstake or claim.'))
       return node
     }
 

--- a/src/js/robinhood_up33.js
+++ b/src/js/robinhood_up33.js
@@ -554,7 +554,7 @@ const Up33 = (function () {
   async function mintOrIncrease() {
     needWallet(); const values = draftValues(); const walletData = values.pool.walletData
     if (!walletData || values.amount0.gt(walletData.allowance0) || values.amount1.gt(walletData.allowance1)) throw new Error('Approve each desired token amount before submitting.')
-    if ((values.min0.isZero() || values.min1.isZero()) && !window.confirm('A zero minimum amount has no slippage protection for that token. vfat.tools does not provide a quote here. Continue?')) return
+    if ((values.min0.isZero() || values.min1.isZero()) && !window.confirm('A zero minimum has no slippage protection for that token. Continue?')) return
     const manager = contract(addresses.manager, managerAbi, state.wallet)
     if (state.editing) return send(manager, 'increaseLiquidity', [{ tokenId: state.editing.id, amount0Desired: values.amount0, amount1Desired: values.amount1, amount0Min: values.min0, amount1Min: values.min1, deadline: deadline() }], 'Increase liquidity for position #' + state.editing.id.toString())
     const range = ticks(values.pool)
@@ -575,7 +575,7 @@ const Up33 = (function () {
     needWallet(); const token0 = poolToken(position.pool, 0); const token1 = poolToken(position.pool, 1)
     const readMin = function (token) { const entry = window.prompt('Minimum ' + token.symbol + ' when exiting #' + position.id.toString() + ' (enter 0 only if you accept no protection):', '0'); if (entry === null) return null; try { return ethers.utils.parseUnits(entry.trim(), token.decimals) } catch (error) { throw new Error('Minimum must be a valid ' + token.symbol + ' amount.') } }
     const min0 = readMin(token0); if (min0 === null) return; const min1 = readMin(token1); if (min1 === null) return
-    if ((min0.isZero() || min1.isZero()) && !window.confirm('At least one exit minimum is zero. This direct transaction is not price-protected for that token. Continue?')) return
+    if ((min0.isZero() || min1.isZero()) && !window.confirm('At least one exit minimum is zero, so that token is not price-protected. Continue?')) return
     const manager = contract(addresses.manager, managerAbi, state.wallet); const calls = []
     if (!position.position.liquidity.isZero()) calls.push(manager.interface.encodeFunctionData('decreaseLiquidity', [{ tokenId: position.id, liquidity: position.position.liquidity, amount0Min: min0, amount1Min: min1, deadline: deadline() }]))
     calls.push(manager.interface.encodeFunctionData('collect', [{ tokenId: position.id, recipient: state.account, amount0Max: max128, amount1Max: max128 }]))
@@ -638,7 +638,7 @@ const Up33 = (function () {
   function renderRegistry() {
     const node = section('All current Up33 farms')
     if (state.registryLoading && !state.pools.length) { node.appendChild(e('pre', { text: 'Reading voter → factory → gauge data from Robinhood RPC…' })); return node }
-    if (!state.pools.length) { node.appendChild(e('pre', { text: 'No current Up33 pool/gauge pairs were returned by the voter and factory.' })); return node }
+    if (!state.pools.length) { node.appendChild(e('pre', { text: 'No Up33 pools.' })); return node }
     const ready = state.pools.filter(function (pool) { return pool.ready })
     if (!ready.length) {
       node.appendChild(e('pre', { text: 'FARMS : ' + state.pools.length + ' current gauge-backed pools\nREADING: pool contracts, token balances, emissions, and the USDG-anchored onchain price graph…' }))
@@ -696,7 +696,7 @@ const Up33 = (function () {
     if (!state.account) { node.appendChild(e('pre', { text: 'Connect a wallet on Robinhood Chain to find direct position-manager NFTs and gauge-staked NFTs.' })); return node }
     if (!onRobinhood()) { node.appendChild(e('pre', { text: 'Switch to Robinhood Chain to load and transact with this wallet’s positions.' })); return node }
     if (state.walletLoading) { node.appendChild(e('pre', { text: 'Reading direct wallet NFTs and gauge stakes…' })); return node }
-    if (!state.positions.length) { node.appendChild(e('pre', { text: 'No direct wallet-owned or gauge-staked Up33 NFTs were found. NFTs held by another smart wallet are intentionally not inferred here.' })); return node }
+    if (!state.positions.length) { node.appendChild(e('pre', { text: 'No wallet or gauge-staked Up33 NFTs.' })); return node }
     state.positions.forEach(function (position) {
       node.appendChild(e('pre', { text: '\nPOSITION: ' + describe(position) + '\nSTATE   : ' + (position.status === 'staked' ? 'Staked in Up33 gauge' : 'In this wallet') }))
       const controls = e('div'); add(controls, document.createTextNode('ACTIONS : '))

--- a/src/js/robinhood_up33.js
+++ b/src/js/robinhood_up33.js
@@ -253,7 +253,7 @@ const Up33 = (function () {
         await refreshMarket(false, true)
         state.selected = state.pools.slice().sort(function (left, right) { return (right.tvl || 0) - (left.tvl || 0) })[0] || state.selected
       }
-      message('Loaded all ' + state.pools.length + ' current Up33 farms with live onchain TVL and emission APR.', 'success')
+      message('Loaded ' + state.pools.length + ' farms.', 'success')
     } finally { state.registryLoading = false; if (!state.marketLoading && !state.walletLoading) setLoading(); render() }
   }
 
@@ -636,20 +636,20 @@ const Up33 = (function () {
   }
 
   function renderRegistry() {
-    const node = section('All current Up33 farms')
-    if (state.registryLoading && !state.pools.length) { node.appendChild(e('pre', { text: 'Reading voter → factory → gauge data from Robinhood RPC…' })); return node }
+    const node = section('Up33 farms')
+    if (state.registryLoading && !state.pools.length) { node.appendChild(e('pre', { text: 'Reading Up33 farms…' })); return node }
     if (!state.pools.length) { node.appendChild(e('pre', { text: 'No Up33 pools.' })); return node }
     const ready = state.pools.filter(function (pool) { return pool.ready })
     if (!ready.length) {
-      node.appendChild(e('pre', { text: 'FARMS : ' + state.pools.length + ' current gauge-backed pools\nREADING: pool contracts, token balances, emissions, and the USDG-anchored onchain price graph…' }))
+      node.appendChild(e('pre', { text: 'FARMS : ' + state.pools.length + '\nReading Up33 farms…' }))
       return node
     }
     const priced = ready.filter(function (pool) { return Number.isFinite(pool.tvl) }).length
     const active = ready.filter(function (pool) { return pool.periodFinish && num(pool.periodFinish) > Math.floor(Date.now() / 1000) && pool.rewardRate && !pool.rewardRate.isZero() })
     const pricedApr = active.filter(function (pool) { return Number.isFinite(pool.apr) }).length
     const totalTvl = ready.reduce(function (sum, pool) { return sum + (Number.isFinite(pool.tvl) ? pool.tvl : 0) }, 0)
-    const progress = ready.length === state.pools.length ? 'all current farms loaded' : ready.length + '/' + state.pools.length + ' farms loaded; rows will update as RPC batches settle'
-    node.appendChild(e('pre', { text: 'FARMS : ' + progress + ' · ' + priced + '/' + ready.length + ' TVLs priced onchain · ' + pricedApr + '/' + active.length + ' live emission APRs priced onchain\nTVL   : ' + usd(totalTvl) + ' across visible farms with a live USDG path\nSOURCE: voter + factory + gauge + pool balances + pool slot0, all on Robinhood RPC\n' }))
+    const loaded = ready.length === state.pools.length ? String(state.pools.length) : ready.length + '/' + state.pools.length
+    node.appendChild(e('pre', { text: 'FARMS : ' + loaded + ' · ' + active.length + ' live\nTVL   : ' + usd(totalTvl) + ' · ' + priced + '/' + ready.length + ' priced\nAPR   : ' + pricedApr + '/' + active.length + ' priced\n' }))
     node.appendChild(e('pre', { className: 'up33-market-table', text: farmTable(ready) }))
     const controls = e('div')
     add(controls, action('Refresh all farms', function () { return refreshMarket(true) }), document.createTextNode('  '))
@@ -685,16 +685,16 @@ const Up33 = (function () {
     const fields = e('div', { className: 'up33-fields' }); add(fields, input(token0.symbol + ' desired', 'up33-amount0', state.draft.amount0, 'Direct ERC-20 amount'), input(token1.symbol + ' desired', 'up33-amount1', state.draft.amount1, 'Direct ERC-20 amount'), input(token0.symbol + ' minimum', 'up33-min0', state.draft.min0 || '0', 'Your slippage floor'), input(token1.symbol + ' minimum', 'up33-min1', state.draft.min1 || '0', 'Your slippage floor'))
     if (!state.editing) { const center = Math.floor(num(pool.slot0.tick) / pool.tickSpacing) * pool.tickSpacing; add(fields, input('Lower tick', 'up33-tick-lower', state.draft.lower || String(center - 10 * pool.tickSpacing), 'Multiple of ' + pool.tickSpacing), input('Upper tick', 'up33-tick-upper', state.draft.upper || String(center + 10 * pool.tickSpacing), 'Multiple of ' + pool.tickSpacing)) }
     node.appendChild(fields); const controls = e('div'); const disabled = !state.account || !onRobinhood(); add(controls, action('Approve ' + token0.symbol, function () { return approveToken(0) }, disabled), document.createTextNode(' '), action('Approve ' + token1.symbol, function () { return approveToken(1) }, disabled), document.createTextNode(' '), action(state.editing ? 'Increase liquidity' : 'Mint position', mintOrIncrease, disabled)); node.appendChild(controls)
-    node.appendChild(e('pre', { text: '\nThe form does not quote or swap. Minimum amounts are supplied exactly as entered; zero minimums require confirmation before signing.' })); if (state.editing) node.appendChild(action('Create a new position instead', function () { return choose(pool, null) })); return node
+    node.appendChild(e('pre', { text: '\nNo quote or swap. Minimums are used exactly as entered.' })); if (state.editing) node.appendChild(action('Create a new position instead', function () { return choose(pool, null) })); return node
   }
   function describe(position) {
     const token0 = poolToken(position.pool, 0); const token1 = poolToken(position.pool, 1); const values = ['#' + position.id.toString(), token0.symbol + ' / ' + token1.symbol, 'range ' + position.position.tickLower + ' to ' + position.position.tickUpper, 'liquidity ' + position.position.liquidity.toString()]
     if (position.status === 'staked' && position.pool.rewardInfo) values.push('earned ' + format(position.earned, position.pool.rewardInfo.decimals) + ' ' + position.pool.rewardInfo.symbol); return values.join(' · ')
   }
   function renderPositions() {
-    const node = section('Your direct Up33 positions')
-    if (!state.account) { node.appendChild(e('pre', { text: 'Connect a wallet on Robinhood Chain to find direct position-manager NFTs and gauge-staked NFTs.' })); return node }
-    if (!onRobinhood()) { node.appendChild(e('pre', { text: 'Switch to Robinhood Chain to load and transact with this wallet’s positions.' })); return node }
+    const node = section('Your positions')
+    if (!state.account) { node.appendChild(e('pre', { text: 'Connect a wallet on Robinhood Chain to see your positions.' })); return node }
+    if (!onRobinhood()) { node.appendChild(e('pre', { text: 'Switch to Robinhood Chain to see your positions.' })); return node }
     if (state.walletLoading) { node.appendChild(e('pre', { text: 'Reading direct wallet NFTs and gauge stakes…' })); return node }
     if (!state.positions.length) { node.appendChild(e('pre', { text: 'No wallet or gauge-staked Up33 NFTs.' })); return node }
     state.positions.forEach(function (position) {
@@ -704,7 +704,7 @@ const Up33 = (function () {
       else add(controls, action('Stake', function () { return stake(position) }), document.createTextNode(' '), action('Collect fees', function () { return collect(position) }), document.createTextNode(' '), action('Increase', function () { return choose(position.pool, position) }), document.createTextNode(' '), action('Exit all', function () { return exit(position) }))
       node.appendChild(controls)
     })
-    node.appendChild(e('pre', { text: '\nExit all removes all NFT liquidity, collects, and burns the NFT in one position-manager multicall. It asks for explicit token minimums before the wallet request.' })); return node
+    node.appendChild(e('pre', { text: '\nExit all removes the liquidity, collects fees, and burns the NFT.' })); return node
   }
   function fatal(error) { setLoading(); const app = byId('up33-app'); if (!app) return; app.textContent = ''; app.appendChild(e('pre', { text: 'UP33 COULD NOT LOAD\n' + errText(error) + '\nThis page only uses the official Robinhood RPC. Check the connection and try again.' })) }
   return { start: start, fatal: fatal }

--- a/src/views/pages/3jane/index.ejs
+++ b/src/views/pages/3jane/index.ejs
@@ -59,7 +59,6 @@ WALLET: <span id="jane-wallet-status">Checking injected wallet permissions...</s
   <div id="jane-rewards" aria-live="polite"></div>
 </section>
 
-<pre class="jane-footer-note">FLOW: exact approval → eth_call → wallet → receipt refresh</pre>
 </main>
 
 <dialog id="jane-action-dialog" class="jane-action-dialog" aria-labelledby="jane-action-title">
@@ -67,7 +66,7 @@ WALLET: <span id="jane-wallet-status">Checking injected wallet permissions...</s
   <div id="jane-action-content"></div>
 </dialog>
 
-<%- include(`${partials}/disclaimer`); -%>
+<pre class="jane-footer"><%- include(`${partials}/disclaimer`); -%></pre>
 <style>
   .jane-page { max-width: 1520px; min-width: 0; margin: 20px 10px 50px; }
   .jane-page, .jane-page * { box-sizing: border-box; font-family: monospace; }

--- a/src/views/pages/3jane/index.ejs
+++ b/src/views/pages/3jane/index.ejs
@@ -66,7 +66,7 @@ WALLET: <span id="jane-wallet-status">Checking injected wallet permissions...</s
   <div id="jane-action-content"></div>
 </dialog>
 
-<pre class="jane-footer"><%- include(`${partials}/disclaimer`); -%></pre>
+<pre class="jane-footer-note"><%- include(`${partials}/disclaimer`); -%></pre>
 <style>
   .jane-page { max-width: 1520px; min-width: 0; margin: 20px 10px 50px; }
   .jane-page, .jane-page * { box-sizing: border-box; font-family: monospace; }

--- a/src/views/pages/robinhood/fables/index.ejs
+++ b/src/views/pages/robinhood/fables/index.ejs
@@ -4,7 +4,7 @@
   noGlobalScripts: true,
   pageMeta: {
     title: 'Fables Ranges on Robinhood Chain | vfat.tools',
-    description: 'Fables range liquidity, onchain TVL, realized fee APRs, and direct wallet actions on Robinhood Chain. Every value comes from the official RPC and onchain contracts.',
+    description: 'Fables range liquidity, onchain TVL, realized fee APRs, and direct wallet actions on Robinhood Chain.',
     url: 'https://vfat.tools/robinhood/fables/',
     image: 'https://vfat.tools/img/robinhood-fables-social.png',
     imageAlt: 'vfat.tools Fables range pool table on Robinhood Chain.',
@@ -17,18 +17,15 @@
 <main class="fables-page">
 <nav class="fables-mobile-nav" aria-label="Fables page navigation"><a href="../">[ Robinhood farms ]</a> <a href="/">[ vfat.tools ]</a></nav>
 <pre id="fables-banner">
-***************** 👨‍🌾 UNOFFICIAL FABLES RANGE CALCULATOR 👨‍🌾 *****************
-CHAIN : Robinhood Chain (4663)
-MODE  : Wallet-only onchain reads and direct wallet transactions. No price API or router.
+==================== FABLES · ROBINHOOD CHAIN ====================
+MODE  : Onchain RPC + direct wallet
 NOTE  : Fables is a Uniswap v4 hook AMM for tokenized equities. Liquidity is held
         as ERC-6909 range shares on each pool's ledger, not as position NFTs.
-FEES  : Swap fees are dynamic and directional. Each pool row shows its own
-        session read from its ledger: equity pools run open / overnight / closed
-        on a US calendar, and pools with no calendar show always-on. APRs below
-        are realized fees over the stated window, not a forward rate.
-SCOPE : This page reads pools and ranges, claims fees, and withdraws. Opening a
-        new range is not offered here.
-**************************************************************************************
+FEES  : Swap fees are dynamic and directional. Equity pools run open / overnight /
+        closed on a US calendar; pools without one are always on. APRs are realized
+        fees over the stated window, not a forward rate.
+SCOPE : Opening a new range is not offered here.
+==================================================================
 </pre>
 <div class="fables-toolbar"><span id="fables-wallet-status"></span> <button id="fables-connect" class="fables-link" type="button">[ connect ]</button> <button id="fables-other-wallet" class="fables-link" type="button">[ other wallet ]</button> <button id="fables-zero-toggle" class="fables-link" type="button">[ show zero APR ]</button> <button id="fables-refresh" class="fables-link" type="button">[ refresh ]</button></div>
 <p id="fables-status" class="fables-status" role="status" hidden></p>

--- a/src/views/pages/robinhood/fables/index.ejs
+++ b/src/views/pages/robinhood/fables/index.ejs
@@ -17,7 +17,8 @@
 <main class="fables-page">
 <nav class="fables-mobile-nav" aria-label="Fables page navigation"><a href="../">[ Robinhood farms ]</a> <a href="/">[ vfat.tools ]</a></nav>
 <pre id="fables-banner">
-==================== FABLES · ROBINHOOD CHAIN ====================
+***************** 👨‍🌾 UNOFFICIAL FABLES RANGE CALCULATOR 👨‍🌾 *****************
+CHAIN : Robinhood Chain (4663)
 MODE  : Onchain RPC + direct wallet
 NOTE  : Fables is a Uniswap v4 hook AMM for tokenized equities. Liquidity is held
         as ERC-6909 range shares on each pool's ledger, not as position NFTs.
@@ -25,7 +26,7 @@ FEES  : Swap fees are dynamic and directional. Equity pools run open / overnight
         closed on a US calendar; pools without one are always on. APRs are realized
         fees over the stated window, not a forward rate.
 SCOPE : Opening a new range is not offered here.
-==================================================================
+**************************************************************************************
 </pre>
 <div class="fables-toolbar"><span id="fables-wallet-status"></span> <button id="fables-connect" class="fables-link" type="button">[ connect ]</button> <button id="fables-other-wallet" class="fables-link" type="button">[ other wallet ]</button> <button id="fables-zero-toggle" class="fables-link" type="button">[ show zero APR ]</button> <button id="fables-refresh" class="fables-link" type="button">[ refresh ]</button></div>
 <p id="fables-status" class="fables-status" role="status" hidden></p>

--- a/src/views/pages/robinhood/morpho/index.ejs
+++ b/src/views/pages/robinhood/morpho/index.ejs
@@ -48,7 +48,6 @@ WALLET: <span id="morpho-wallet-status">Checking injected wallet permissions...<
   <div id="morpho-vaults" class="morpho-table-wrap" aria-live="polite"></div>
 </section>
 
-<pre class="morpho-footer-note">FLOW: exact approval → eth_call → wallet → receipt refresh</pre>
 </main>
 
 <dialog id="morpho-action-dialog" class="morpho-action-dialog" aria-labelledby="morpho-action-title">
@@ -56,7 +55,7 @@ WALLET: <span id="morpho-wallet-status">Checking injected wallet permissions...<
   <div id="morpho-action-content"></div>
 </dialog>
 
-<%- include(`${partials}/disclaimer`); -%>
+<pre class="morpho-footer"><%- include(`${partials}/disclaimer`); -%></pre>
 <style>
   .morpho-page { max-width: 1500px; margin: 20px 10px 50px; min-width: 0; }
   .morpho-page, .morpho-page * { font-family: monospace; box-sizing: border-box; }

--- a/src/views/pages/robinhood/morpho/index.ejs
+++ b/src/views/pages/robinhood/morpho/index.ejs
@@ -55,7 +55,7 @@ WALLET: <span id="morpho-wallet-status">Checking injected wallet permissions...<
   <div id="morpho-action-content"></div>
 </dialog>
 
-<pre class="morpho-footer"><%- include(`${partials}/disclaimer`); -%></pre>
+<pre class="morpho-footer-note"><%- include(`${partials}/disclaimer`); -%></pre>
 <style>
   .morpho-page { max-width: 1500px; margin: 20px 10px 50px; min-width: 0; }
   .morpho-page, .morpho-page * { font-family: monospace; box-sizing: border-box; }

--- a/src/views/pages/robinhood/semi/index.ejs
+++ b/src/views/pages/robinhood/semi/index.ejs
@@ -4,7 +4,7 @@
   noGlobalScripts: true,
   pageMeta: {
     title: 'SemiVault Farms on Robinhood Chain | vfat.tools',
-    description: 'Live SemiVault staking TVL, conditional emission history, and direct wallet actions on Robinhood Chain. Every value comes from the official RPC and onchain contracts.',
+    description: 'SemiVault staking TVL, conditional emission history, and direct wallet actions on Robinhood Chain.',
     url: 'https://vfat.tools/robinhood/semi/',
     image: 'https://vfat.tools/img/robinhood-semi-social-v3.png',
     imageAlt: 'vfat.tools SemiVault staking information for Robinhood Chain.',
@@ -16,17 +16,16 @@
 <body>
 <%- include(`${partials}/header_main`); -%>
 <pre id="semi-banner">
-***************** 👨‍🌾 UNOFFICIAL SEMIVAULT STAKING CALCULATOR 👨‍🌾 *****************
-INFO  : https://semivault.xyz
-CHAIN : Robinhood Chain (4663)
-MODE  : Wallet-only onchain reads and direct wallet transactions. No price API or router.
+==================== SEMIVAULT · ROBINHOOD CHAIN ====================
+APP   : <a href="https://semivault.xyz" target="_blank" rel="noopener noreferrer">semivault.xyz</a>
+MODE  : Onchain RPC + direct wallet
 NOTE  : Emissions are conditional. The ratchet mints only when the backing
-        ratio sets a new high. Some epochs pay nothing. No forward APR is shown.
-**************************************************************************************
+        ratio sets a new high, so some epochs pay nothing.
+=====================================================================
 
 </pre>
 <div id="semi-loading" class="semi-loading" role="status" aria-live="polite">
-  <span id="semi-loading-spinner" class="semi-spinner" aria-hidden="true">[....]</span> <span id="semi-loading-text">Reading SemiVault contracts on Robinhood Chain…</span>
+  <span id="semi-loading-spinner" class="semi-spinner" aria-hidden="true">[....]</span> <span id="semi-loading-text">Reading SemiVault…</span>
 </div>
 <div id="semi-app" aria-live="polite"></div>
 <pre class="semi-footer"><%- include(`${partials}/disclaimer`); -%></pre>

--- a/src/views/pages/robinhood/semi/index.ejs
+++ b/src/views/pages/robinhood/semi/index.ejs
@@ -16,12 +16,13 @@
 <body>
 <%- include(`${partials}/header_main`); -%>
 <pre id="semi-banner">
-==================== SEMIVAULT · ROBINHOOD CHAIN ====================
+***************** 👨‍🌾 UNOFFICIAL SEMIVAULT STAKING CALCULATOR 👨‍🌾 *****************
 APP   : <a href="https://semivault.xyz" target="_blank" rel="noopener noreferrer">semivault.xyz</a>
+CHAIN : Robinhood Chain (4663)
 MODE  : Onchain RPC + direct wallet
 NOTE  : Emissions are conditional. The ratchet mints only when the backing
         ratio sets a new high, so some epochs pay nothing.
-=====================================================================
+**************************************************************************************
 
 </pre>
 <div id="semi-loading" class="semi-loading" role="status" aria-live="polite">

--- a/src/views/pages/robinhood/up33/index.ejs
+++ b/src/views/pages/robinhood/up33/index.ejs
@@ -16,10 +16,11 @@
 <body>
 <%- include(`${partials}/header_main`); -%>
 <pre id="up33-banner">
-==================== UP33 · ROBINHOOD CHAIN ====================
+******************* 👨‍🌾 UNOFFICIAL UP33 FARMING CALCULATOR 👨‍🌾 *******************
 APP   : <a href="https://up33.xyz" target="_blank" rel="noopener noreferrer">up33.xyz</a>
+CHAIN : Robinhood Chain (4663)
 MODE  : Onchain RPC + direct wallet
-================================================================
+**************************************************************************************
 
 </pre>
 <div id="up33-loading" class="up33-loading" role="status" aria-live="polite">

--- a/src/views/pages/robinhood/up33/index.ejs
+++ b/src/views/pages/robinhood/up33/index.ejs
@@ -37,8 +37,8 @@ MODE  : Onchain RPC + direct wallet
   .up33-form-label { display: block; margin: 7px 0; }
   .up33-form-label input { margin-left: 8px; font: inherit; }
   #up33-app, #up33-app section { min-width: 0; }
-  #up33-banner, #up33-app pre { box-sizing: border-box; max-width: 100%; }
-  #up33-banner, #up33-app pre:not(.up33-market-table) { overflow-wrap: anywhere; white-space: pre-wrap; }
+  #up33-banner, #up33-app pre, .up33-footer { box-sizing: border-box; max-width: 100%; }
+  #up33-banner, #up33-app pre:not(.up33-market-table), .up33-footer { overflow-wrap: anywhere; white-space: pre-wrap; }
   .up33-market-table { overflow-x: auto; white-space: pre; }
 </style>
 <%- include(`${partials}/scripts_onchain`, {scriptname: 'robinhood_up33'}); -%>

--- a/src/views/pages/robinhood/up33/index.ejs
+++ b/src/views/pages/robinhood/up33/index.ejs
@@ -4,10 +4,10 @@
   noGlobalScripts: true,
   pageMeta: {
     title: 'Up33 Farms on Robinhood Chain | vfat.tools',
-    description: 'Live Up33 farm TVL, emission APRs, and direct wallet actions on Robinhood Chain. Every value comes from the official RPC and onchain contracts.',
+    description: 'Up33 farm TVL, emission APRs, and direct wallet actions on Robinhood Chain.',
     url: 'https://vfat.tools/robinhood/up33/',
     image: 'https://vfat.tools/img/robinhood-up33-social-v2.png',
-    imageAlt: 'Live vfat.tools Up33 farm table on Robinhood Chain.',
+    imageAlt: 'vfat.tools Up33 farm table on Robinhood Chain.',
     imageWidth: 1200,
     imageHeight: 630
   }
@@ -16,18 +16,17 @@
 <body>
 <%- include(`${partials}/header_main`); -%>
 <pre id="up33-banner">
-******************* 👨‍🌾 UNOFFICIAL UP33 FARMING CALCULATOR 👨‍🌾 *******************
-INFO  : https://up33.xyz
-CHAIN : Robinhood Chain (4663)
-MODE  : Wallet-only onchain reads and direct wallet transactions. No price API or router.
-**************************************************************************************
+==================== UP33 · ROBINHOOD CHAIN ====================
+APP   : <a href="https://up33.xyz" target="_blank" rel="noopener noreferrer">up33.xyz</a>
+MODE  : Onchain RPC + direct wallet
+================================================================
 
 </pre>
 <div id="up33-loading" class="up33-loading" role="status" aria-live="polite">
-  <span id="up33-loading-spinner" class="up33-spinner" aria-hidden="true">[....]</span> <span id="up33-loading-text">Reading Up33 contracts on Robinhood Chain…</span>
+  <span id="up33-loading-spinner" class="up33-spinner" aria-hidden="true">[....]</span> <span id="up33-loading-text">Reading Up33 farms…</span>
 </div>
 <div id="up33-app" aria-live="polite"></div>
-<%- include(`${partials}/disclaimer`); -%>
+<pre class="up33-footer"><%- include(`${partials}/disclaimer`); -%></pre>
 <style>
   .up33-action { margin: 0; padding: 0; border: 0; background: transparent; color: inherit; cursor: pointer; font: inherit; text-decoration: underline; }
   .up33-action:disabled { cursor: not-allowed; opacity: .45; text-decoration: none; }


### PR DESCRIPTION
`948651f1c3` "Tighten Robinhood farm page copy" cut alandale, catnip, giga and
morpho. **semi, up33 and fables were never covered.** Morpho and 3Jane also kept a
footer line that fails the same test the commit was applying, and three pages
render the shared disclaimer as one collapsed line.

### The footer line

`FLOW: exact approval → eth_call → wallet → receipt refresh` is deleted from morpho
and 3Jane. It describes how the page sends a transaction, which is exactly what the
standard exists to remove. `948651f1c3` compressed three verbose footers into that
one line, but **eleven of thirteen pages carry no footer at all** — it was residue,
not a pattern. Compressed slop is still slop.

### The disclaimer was rendering as one run-on line

The partial is raw preformatted text with no block wrapper, so it depends on sitting
inside a `<pre>`. All 78 pages that render it correctly have it inside
`<pre class="container">`. Morpho, up33 and 3Jane included it as a bare sibling, so
the newlines collapsed:

```
* This project has recently been updated. *** Disclaimer *** I am in no way affiliated with the above projects, nor do I endorse them. …
```

Wrapped at those three call sites, matching what semi and fables already do. The
built pages now preserve all nine newlines, same as the pages that were already
correct.

### Copy

| Page | Before | After |
| --- | --- | --- |
| semi, up33, fables | `Live … Every value comes from the official RPC and onchain contracts.` | the list, then `on Robinhood Chain.` |
| semi, up33, fables | `INFO  : https://x.xyz` + `MODE : Wallet-only onchain reads … No price API or router.` | an `APP` link and `MODE  : Onchain RPC + direct wallet`. The `UNOFFICIAL … CALCULATOR` title, its `*` rules, its 👨‍🌾 and the `CHAIN` line are left alone |
| up33 | `SOURCE: voter + factory + gauge + pool balances + pool slot0, all on Robinhood RPC` | deleted |
| up33 | `FARMS : all current farms loaded · 72/75 TVLs priced onchain · 65/65 live emission APRs priced onchain` | `FARMS : 75 · 65 live` / `TVL   : $8.84m · 72/75 priced` / `APR   : 65/65 priced` |
| up33 | `Loaded all 75 current Up33 farms with live onchain TVL and emission APR.` | `Loaded 75 farms.` |
| up33 | `All current Up33 farms` / `Your direct Up33 positions` | `Up33 farms` / `Your positions` |
| up33 | `NFTs held by another smart wallet are intentionally not inferred here.` | deleted |
| up33 | `vfat.tools does not provide a quote here.` | deleted |
| up33 | `… burns the NFT in one position-manager multicall. It asks for explicit token minimums before the wallet request.` | `… collects fees, and burns the NFT.` |
| semi | `No price API is used.` | deleted |
| semi | `Everything above is read without a wallet. Connect only to stake, unstake or claim.` | `Connect to stake, unstake or claim.` |

Protocol facts are kept: SemiVault's conditional ratchet, Fables' ERC-6909 range
shares and its directional, session-dependent swap fees, and what an Up33 exit
destroys. Fables' `SCOPE` keeps only the part a user acts on — that opening a new
range is not offered here — and drops the inventory of what the page does do. That
one is a judgement call; it describes the page, but deleting it sends people hunting
for a button that does not exist.

### On the banner title

An earlier commit on this branch converted those three banners to a
`==== NAME · CHAIN ====` title. That was wrong and is reverted. `UNOFFICIAL <X>
CALCULATOR` is on **2014 pages** — it is the site signature and a statement of
non-affiliation that pairs with the disclaimer partial, so removing it deleted a
disclaimer rather than decoration. The title, its `*` rules and its 👨‍🌾 are restored
verbatim, and `CHAIN :` comes back with them since the chain is no longer in the
title. Only the copy below the title is changed.

The skill reference now says never to touch it, and records that alandale
(converted by `948651f1c3`), morpho and 3Jane are the exceptions rather than a
licence to spread that shape.

### Verification

- `node --check` on all three changed JS files; full `npm run build` exit 0 with
  `check:no-localhost` and `check:wallet-connector` passing, one app bundle,
  `Missing REOWN_PROJECT_ID` count 0.
- Disclaimer newline counts in the built HTML: morpho, up33 and 3Jane now 9, equal
  to semi and fables as controls.
- up33 rendered from a clean production build and read end to end, including the
  footer.

One process note worth recording: the first pass matched string literals and missed
every fragment-assembled string — the `SOURCE:` line and the whole `FARMS :` block
survived a clean grep and only a render caught them. My first render then showed the
*old* copy, because `build:js` left the previous run's hashed bundle in `dist/` and
the HTML still referenced it. Both lessons are now in the page-copy skill reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBwAC7oF7yoYEPRj633VUo
